### PR TITLE
🚨(lint) Update prettier config and lint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,16 +5,15 @@ module.exports = {
     mocha: true,
     node: true,
   },
-  plugins: ["@typescript-eslint"],
-  extends: ["plugin:prettier/recommended", "plugin:node/recommended"],
-  parser: "@typescript-eslint/parser",
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 12,
   },
-  rules: {
-    "node/no-missing-import": "off",
-    "node/no-extraneous-import": "off",
-    "no-unused-expressions": "off",
-    "node/no-unsupported-features/es-syntax": "off",
-  },
+  rules: {},
 };

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,6 @@
 {
+  "trailingComma": "all",
+  "singleQuote": true,
   "overrides": [
     {
       "files": "*.sol",

--- a/.solhint.json
+++ b/.solhint.json
@@ -25,6 +25,7 @@
     "no-unused-vars": "error",
     "payable-fallback": "error",
     "no-empty-blocks": "error",
+    "no-global-import": "off",
     "constructor-syntax": "error",
     "not-rely-on-time": "off",
     "reason-string": "off"

--- a/.solhint.json
+++ b/.solhint.json
@@ -24,11 +24,10 @@
     "max-states-count": ["error", 15],
     "no-unused-vars": "error",
     "payable-fallback": "error",
+    "no-empty-blocks": "error",
     "constructor-syntax": "error",
     "not-rely-on-time": "off",
-    "reason-string": "off",
-    "no-global-import": "off",
-    "no-empty-blocks": "off"
+    "reason-string": "off"
   },
   "plugins": ["prettier"]
 }

--- a/contracts/compliance/legacy/DefaultCompliance.sol
+++ b/contracts/compliance/legacy/DefaultCompliance.sol
@@ -68,11 +68,10 @@ contract DefaultCompliance is BasicCompliance {
     /**
      *  @dev See {ICompliance-transferred}.
      */
-    // solhint-disable-next-line no-empty-blocks
     function transferred(
         address _from,
         address _to,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) external override {}
 
     /**

--- a/contracts/compliance/legacy/features/ApproveTransfer.sol
+++ b/contracts/compliance/legacy/features/ApproveTransfer.sol
@@ -228,10 +228,9 @@ abstract contract ApproveTransfer is BasicCompliance {
      *  @param _value the amount of tokens minted on `_to` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _creationActionOnApproveTransfer(
         address _to,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**
@@ -241,10 +240,9 @@ abstract contract ApproveTransfer is BasicCompliance {
      *  @param _value the amount of tokens burnt from `_from` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _destructionActionOnApproveTransfer(
         address _from,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**

--- a/contracts/compliance/legacy/features/CountryRestrictions.sol
+++ b/contracts/compliance/legacy/features/CountryRestrictions.sol
@@ -174,11 +174,10 @@ abstract contract CountryRestrictions is BasicCompliance {
      *  @param _value the amount of tokens that `_from` sent to `_to`
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _transferActionOnCountryRestrictions(
         address _from,
         address _to,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**
@@ -188,10 +187,9 @@ abstract contract CountryRestrictions is BasicCompliance {
      *  @param _value the amount of tokens minted on `_to` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _creationActionOnCountryRestrictions(
         address _to,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**
@@ -201,9 +199,8 @@ abstract contract CountryRestrictions is BasicCompliance {
      *  @param _value the amount of tokens burnt from `_from` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _destructionActionOnCountryRestrictions(
         address _from,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 }

--- a/contracts/compliance/legacy/features/CountryWhitelisting.sol
+++ b/contracts/compliance/legacy/features/CountryWhitelisting.sol
@@ -178,11 +178,10 @@ abstract contract CountryWhitelisting is BasicCompliance {
      *  @param _value the amount of tokens that `_from` sent to `_to`
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _transferActionOnCountryWhitelisting(
         address _from,
         address _to,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**
@@ -192,10 +191,9 @@ abstract contract CountryWhitelisting is BasicCompliance {
      *  @param _value the amount of tokens minted on `_to` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _creationActionOnCountryWhitelisting(
         address _to,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**
@@ -205,9 +203,8 @@ abstract contract CountryWhitelisting is BasicCompliance {
      *  @param _value the amount of tokens burnt from `_from` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _destructionActionOnCountryWhitelisting(
         address _from,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 }

--- a/contracts/compliance/legacy/features/DayMonthLimits.sol
+++ b/contracts/compliance/legacy/features/DayMonthLimits.sol
@@ -182,10 +182,9 @@ abstract contract DayMonthLimits is BasicCompliance {
      *  @param _value the amount of tokens minted on `_to` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _creationActionOnDayMonthLimits(
         address _to,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**
@@ -195,10 +194,9 @@ abstract contract DayMonthLimits is BasicCompliance {
      *  @param _value the amount of tokens burnt from `_from` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _destructionActionOnDayMonthLimits(
         address _from,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**

--- a/contracts/compliance/legacy/features/ExchangeMonthlyLimits.sol
+++ b/contracts/compliance/legacy/features/ExchangeMonthlyLimits.sol
@@ -269,10 +269,9 @@ abstract contract ExchangeMonthlyLimits is BasicCompliance {
      *  @param _value the amount of tokens minted on `_to` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _creationActionOnExchangeMonthlyLimits(
         address _to,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**
@@ -282,10 +281,9 @@ abstract contract ExchangeMonthlyLimits is BasicCompliance {
      *  @param _value the amount of tokens burnt from `_from` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _destructionActionOnExchangeMonthlyLimits(
         address _from,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**

--- a/contracts/compliance/legacy/features/SupplyLimit.sol
+++ b/contracts/compliance/legacy/features/SupplyLimit.sol
@@ -110,11 +110,10 @@ abstract contract SupplyLimit is BasicCompliance {
      *  @param _value the amount of tokens that `_from` sent to `_to`
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _transferActionOnSupplyLimit(
         address _from,
         address _to,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 
     /**
@@ -139,9 +138,8 @@ abstract contract SupplyLimit is BasicCompliance {
      *  @param _value the amount of tokens burnt from `_from` wallet
      *  internal function, can be called only from the functions of the Compliance smart contract
      */
-    // solhint-disable-next-line no-empty-blocks
     function _destructionActionOnSupplyLimit(
         address _from,
-        uint256 _value
+        uint256 _value // solhint-disable-next-line no-empty-blocks
     ) internal {}
 }

--- a/contracts/compliance/modular/modules/ConditionalTransferModule.sol
+++ b/contracts/compliance/modular/modules/ConditionalTransferModule.sol
@@ -178,21 +178,27 @@ contract ConditionalTransferModule is AbstractModule {
      *  @dev See {IModule-moduleMintAction}.
      *  no mint action required in this module
      */
-    // solhint-disable-next-line no-empty-blocks
     function moduleMintAction(
         address _to,
         uint256 _value
-    ) external override onlyComplianceCall {}
+    )
+        external
+        override
+        onlyComplianceCall // solhint-disable-next-line no-empty-blocks
+    {}
 
     /**
      *  @dev See {IModule-moduleBurnAction}.
      *  no burn action required in this module
      */
-    // solhint-disable-next-line no-empty-blocks
     function moduleBurnAction(
         address _from,
         uint256 _value
-    ) external override onlyComplianceCall {}
+    )
+        external
+        override
+        onlyComplianceCall // solhint-disable-next-line no-empty-blocks
+    {}
 
     /**
      *  @dev See {IModule-moduleCheck}.

--- a/contracts/compliance/modular/modules/CountryAllowModule.sol
+++ b/contracts/compliance/modular/modules/CountryAllowModule.sol
@@ -159,32 +159,41 @@ contract CountryAllowModule is AbstractModule {
      *  @dev See {IModule-moduleTransferAction}.
      *  no transfer action required in this module
      */
-    // solhint-disable-next-line no-empty-blocks
     function moduleTransferAction(
         address _from,
         address _to,
         uint256 _value
-    ) external override onlyComplianceCall {}
+    )
+        external
+        override
+        onlyComplianceCall // solhint-disable-next-line no-empty-blocks
+    {}
 
     /**
      *  @dev See {IModule-moduleMintAction}.
      *  no mint action required in this module
      */
-    // solhint-disable-next-line no-empty-blocks
     function moduleMintAction(
         address _to,
         uint256 _value
-    ) external override onlyComplianceCall {}
+    )
+        external
+        override
+        onlyComplianceCall // solhint-disable-next-line no-empty-blocks
+    {}
 
     /**
      *  @dev See {IModule-moduleBurnAction}.
      *  no burn action required in this module
      */
-    // solhint-disable-next-line no-empty-blocks
     function moduleBurnAction(
         address _from,
         uint256 _value
-    ) external override onlyComplianceCall {}
+    )
+        external
+        override
+        onlyComplianceCall // solhint-disable-next-line no-empty-blocks
+    {}
 
     /**
      *  @dev See {IModule-moduleCheck}.

--- a/contracts/compliance/modular/modules/CountryRestrictModule.sol
+++ b/contracts/compliance/modular/modules/CountryRestrictModule.sol
@@ -180,32 +180,41 @@ contract CountryRestrictModule is AbstractModule {
      *  @dev See {IModule-moduleTransferAction}.
      *  no transfer action required in this module
      */
-    // solhint-disable-next-line no-empty-blocks
     function moduleTransferAction(
         address _from,
         address _to,
         uint256 _value
-    ) external override onlyComplianceCall {}
+    )
+        external
+        override
+        onlyComplianceCall // solhint-disable-next-line no-empty-blocks
+    {}
 
     /**
      *  @dev See {IModule-moduleMintAction}.
      *  no mint action required in this module
      */
-    // solhint-disable-next-line no-empty-blocks
     function moduleMintAction(
         address _to,
         uint256 _value
-    ) external override onlyComplianceCall {}
+    )
+        external
+        override
+        onlyComplianceCall // solhint-disable-next-line no-empty-blocks
+    {}
 
     /**
      *  @dev See {IModule-moduleBurnAction}.
      *  no burn action required in this module
      */
-    // solhint-disable-next-line no-empty-blocks
     function moduleBurnAction(
         address _from,
         uint256 _value
-    ) external override onlyComplianceCall {}
+    )
+        external
+        override
+        onlyComplianceCall // solhint-disable-next-line no-empty-blocks
+    {}
 
     /**
      *  @dev See {IModule-moduleCheck}.

--- a/contracts/token/Token.sol
+++ b/contracts/token/Token.sol
@@ -726,10 +726,9 @@ contract Token is IToken, AgentRoleUpgradeable, TokenStorage {
     /**
      *  @dev See {ERC20-_beforeTokenTransfer}.
      */
-    // solhint-disable-next-line no-empty-blocks
     function _beforeTokenTransfer(
         address _from,
         address _to,
-        uint256 _amount
+        uint256 _amount // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,13 +1,13 @@
-import "@xyrusworx/hardhat-solidity-json";
-import "@nomicfoundation/hardhat-toolbox";
-import { HardhatUserConfig } from "hardhat/config";
-import "solidity-coverage";
-import "@nomiclabs/hardhat-solhint";
-import "@primitivefi/hardhat-dodoc";
+import '@xyrusworx/hardhat-solidity-json';
+import '@nomicfoundation/hardhat-toolbox';
+import { HardhatUserConfig } from 'hardhat/config';
+import 'solidity-coverage';
+import '@nomiclabs/hardhat-solhint';
+import '@primitivefi/hardhat-dodoc';
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.17",
+    version: '0.8.17',
     settings: {
       optimizer: {
         enabled: true,
@@ -18,12 +18,12 @@ const config: HardhatUserConfig = {
   dodoc: {
     runOnCompile: false,
     debugMode: true,
-    outputDir: "./docgen",
+    outputDir: './docgen',
     freshOutput: true,
   },
   gasReporter: {
     enabled: process.env.REPORT_GAS !== undefined,
-    currency: "USD",
+    currency: 'USD',
   },
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,10 +2,10 @@ type ContractJSON = {
   _format: string;
   contractName: string;
   sourcename: string;
-  abi: any[];
+  abi: Record<string, unknown>[];
   bytecode: string;
   deployedBytecode: string;
-  linkReferences: any;
+  linkReferences: Record<string, unknown>;
 };
 
 export namespace contracts {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
   "dependencies": {
     "@onchain-id/solidity": "^2.0.0",
     "@openzeppelin/contracts": "^4.8.3",
-    "@openzeppelin/contracts-upgradeable": "^4.8.3",
-    "hardhat": "^2.14.0"
+    "@openzeppelin/contracts-upgradeable": "^4.8.3"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
@@ -55,8 +54,8 @@
     "@typescript-eslint/parser": "^5.59.5",
     "@xyrusworx/hardhat-solidity-json": "^1.0.2",
     "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "hardhat": "^2.14.0",
     "husky": "^8.0.3",
     "prettier": "^2.8.8",
     "solhint-plugin-prettier": "^0.0.5"

--- a/test/agentManager.test.ts
+++ b/test/agentManager.test.ts
@@ -1,12 +1,12 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { deployFullSuiteFixture } from "./fixtures/deploy-full-suite.fixture";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { deployFullSuiteFixture } from './fixtures/deploy-full-suite.fixture';
 
-describe("AgentManager", () => {
-  describe(".callForceTransfer", () => {
-    describe("when specified identity is missing the TransferManager role", () => {
-      it("Should revert", async () => {
+describe('AgentManager', () => {
+  describe('.callForceTransfer', () => {
+    describe('when specified identity is missing the TransferManager role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -20,14 +20,14 @@ describe("AgentManager", () => {
               aliceWallet.address,
               bobWallet.address,
               200,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Transfer Manager");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Transfer Manager');
       });
     });
 
-    describe("when specified identity has the TransferManager role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the TransferManager role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, aliceWallet, bobWallet, anotherWallet },
@@ -45,14 +45,14 @@ describe("AgentManager", () => {
               aliceWallet.address,
               bobWallet.address,
               200,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Transfer Manager");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Transfer Manager');
       });
     });
 
-    describe("when identity has the TransferManager role and the sender is authorized for it", () => {
-      it("Should perform the transfer", async () => {
+    describe('when identity has the TransferManager role and the sender is authorized for it', () => {
+      it('Should perform the transfer', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -69,19 +69,19 @@ describe("AgentManager", () => {
             aliceWallet.address,
             bobWallet.address,
             200,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(transferTx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(aliceWallet.address, bobWallet.address, 200);
       });
     });
   });
 
-  describe(".callBatchForceTransfer", () => {
-    describe("when specified identity is missing the TransferManager role", () => {
-      it("Should revert", async () => {
+  describe('.callBatchForceTransfer', () => {
+    describe('when specified identity is missing the TransferManager role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -95,14 +95,14 @@ describe("AgentManager", () => {
               [aliceWallet.address, bobWallet.address],
               [bobWallet.address, aliceWallet.address],
               [200, 200],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Transfer Manager");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Transfer Manager');
       });
     });
 
-    describe("when specified identity has the TransferManager role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the TransferManager role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, aliceWallet, bobWallet, anotherWallet },
@@ -120,14 +120,14 @@ describe("AgentManager", () => {
               [aliceWallet.address, bobWallet.address],
               [bobWallet.address, aliceWallet.address],
               [200, 200],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Transfer Manager");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Transfer Manager');
       });
     });
 
-    describe("when identity has the TransferManager role and the sender is authorized for it", () => {
-      it("Should perform the transfer", async () => {
+    describe('when identity has the TransferManager role and the sender is authorized for it', () => {
+      it('Should perform the transfer', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -144,22 +144,22 @@ describe("AgentManager", () => {
             [aliceWallet.address, bobWallet.address],
             [bobWallet.address, aliceWallet.address],
             [200, 200],
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(transferTx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(aliceWallet.address, bobWallet.address, 200);
         await expect(transferTx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(bobWallet.address, aliceWallet.address, 200);
       });
     });
   });
 
-  describe(".callPause", () => {
-    describe("when specified identity is missing the Freezer role", () => {
-      it("Should revert", async () => {
+  describe('.callPause', () => {
+    describe('when specified identity is missing the Freezer role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet },
@@ -167,13 +167,13 @@ describe("AgentManager", () => {
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(
-          agentManager.connect(aliceWallet).callPause(aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+          agentManager.connect(aliceWallet).callPause(aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when specified identity has the Freezer role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the Freezer role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, anotherWallet },
@@ -185,13 +185,13 @@ describe("AgentManager", () => {
           .addFreezer(aliceIdentity.address);
 
         await expect(
-          agentManager.connect(anotherWallet).callPause(aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+          agentManager.connect(anotherWallet).callPause(aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when identity has the Freezer role and the sender is authorized for it", () => {
-      it("Should perform the pause", async () => {
+    describe('when identity has the Freezer role and the sender is authorized for it', () => {
+      it('Should perform the pause', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet },
@@ -207,16 +207,16 @@ describe("AgentManager", () => {
           .callPause(aliceIdentity.address);
 
         await expect(pauseTx)
-          .to.emit(token, "Paused")
+          .to.emit(token, 'Paused')
           .withArgs(agentManager.address);
         await expect(token.paused()).to.be.eventually.true;
       });
     });
   });
 
-  describe(".callUnpause", () => {
-    describe("when specified identity is missing the Freezer role", () => {
-      it("Should revert", async () => {
+  describe('.callUnpause', () => {
+    describe('when specified identity is missing the Freezer role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet },
@@ -224,13 +224,13 @@ describe("AgentManager", () => {
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(
-          agentManager.connect(aliceWallet).callUnpause(aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+          agentManager.connect(aliceWallet).callUnpause(aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when specified identity has the Freezer role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the Freezer role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, anotherWallet },
@@ -242,13 +242,15 @@ describe("AgentManager", () => {
           .addFreezer(aliceIdentity.address);
 
         await expect(
-          agentManager.connect(anotherWallet).callUnpause(aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+          agentManager
+            .connect(anotherWallet)
+            .callUnpause(aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when identity has the Freezer role and the sender is authorized for it", () => {
-      it("Should perform the pause", async () => {
+    describe('when identity has the Freezer role and the sender is authorized for it', () => {
+      it('Should perform the pause', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet },
@@ -268,15 +270,15 @@ describe("AgentManager", () => {
           .callUnpause(aliceIdentity.address);
 
         await expect(pauseTx)
-          .to.emit(token, "Unpaused")
+          .to.emit(token, 'Unpaused')
           .withArgs(agentManager.address);
       });
     });
   });
 
-  describe(".callMint", () => {
-    describe("when specified identity is missing the SupplyModifier role", () => {
-      it("Should revert", async () => {
+  describe('.callMint', () => {
+    describe('when specified identity is missing the SupplyModifier role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -286,13 +288,13 @@ describe("AgentManager", () => {
         await expect(
           agentManager
             .connect(aliceWallet)
-            .callMint(bobWallet.address, 1000, aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT Supply Modifier");
+            .callMint(bobWallet.address, 1000, aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT Supply Modifier');
       });
     });
 
-    describe("when specified identity has the SupplyModifier role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the SupplyModifier role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, bobWallet, anotherWallet },
@@ -306,13 +308,13 @@ describe("AgentManager", () => {
         await expect(
           agentManager
             .connect(anotherWallet)
-            .callMint(bobWallet.address, 1000, aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT Supply Modifier");
+            .callMint(bobWallet.address, 1000, aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT Supply Modifier');
       });
     });
 
-    describe("when identity has the SupplyModifier role and the sender is authorized for it", () => {
-      it("Should perform the mint", async () => {
+    describe('when identity has the SupplyModifier role and the sender is authorized for it', () => {
+      it('Should perform the mint', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -328,15 +330,15 @@ describe("AgentManager", () => {
           .callMint(bobWallet.address, 1000, aliceIdentity.address);
 
         await expect(mintTx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(ethers.constants.AddressZero, bobWallet.address, 1000);
       });
     });
   });
 
-  describe(".callBatchMint", () => {
-    describe("when specified identity is missing the SupplyModifier role", () => {
-      it("Should revert", async () => {
+  describe('.callBatchMint', () => {
+    describe('when specified identity is missing the SupplyModifier role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -349,14 +351,14 @@ describe("AgentManager", () => {
             .callBatchMint(
               [bobWallet.address, aliceWallet.address],
               [1000, 500],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Supply Modifier");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Supply Modifier');
       });
     });
 
-    describe("when specified identity has the SupplyModifier role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the SupplyModifier role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, aliceWallet, bobWallet, anotherWallet },
@@ -373,14 +375,14 @@ describe("AgentManager", () => {
             .callBatchMint(
               [bobWallet.address, aliceWallet.address],
               [1000, 500],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Supply Modifier");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Supply Modifier');
       });
     });
 
-    describe("when identity has the SupplyModifier role and the sender is authorized for it", () => {
-      it("Should perform the batch mint", async () => {
+    describe('when identity has the SupplyModifier role and the sender is authorized for it', () => {
+      it('Should perform the batch mint', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -396,22 +398,22 @@ describe("AgentManager", () => {
           .callBatchMint(
             [bobWallet.address, aliceWallet.address],
             [1000, 500],
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(mintTx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(ethers.constants.AddressZero, bobWallet.address, 1000);
         await expect(mintTx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(ethers.constants.AddressZero, aliceWallet.address, 500);
       });
     });
   });
 
-  describe(".callBurn", () => {
-    describe("when specified identity is missing the SupplyModifier role", () => {
-      it("Should revert", async () => {
+  describe('.callBurn', () => {
+    describe('when specified identity is missing the SupplyModifier role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -421,13 +423,13 @@ describe("AgentManager", () => {
         await expect(
           agentManager
             .connect(aliceWallet)
-            .callBurn(bobWallet.address, 1000, aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT Supply Modifier");
+            .callBurn(bobWallet.address, 1000, aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT Supply Modifier');
       });
     });
 
-    describe("when specified identity has the SupplyModifier role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the SupplyModifier role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, bobWallet, anotherWallet },
@@ -441,13 +443,13 @@ describe("AgentManager", () => {
         await expect(
           agentManager
             .connect(anotherWallet)
-            .callBurn(bobWallet.address, 200, bobIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT Supply Modifier");
+            .callBurn(bobWallet.address, 200, bobIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT Supply Modifier');
       });
     });
 
-    describe("when identity has the SupplyModifier role and the sender is authorized for it", () => {
-      it("Should perform the burn", async () => {
+    describe('when identity has the SupplyModifier role and the sender is authorized for it', () => {
+      it('Should perform the burn', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, bobWallet },
@@ -463,15 +465,15 @@ describe("AgentManager", () => {
           .callBurn(bobWallet.address, 200, bobIdentity.address);
 
         await expect(burnTx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(bobWallet.address, ethers.constants.AddressZero, 200);
       });
     });
   });
 
-  describe(".callBatchBurn", () => {
-    describe("when specified identity is missing the SupplyModifier role", () => {
-      it("Should revert", async () => {
+  describe('.callBatchBurn', () => {
+    describe('when specified identity is missing the SupplyModifier role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -484,14 +486,14 @@ describe("AgentManager", () => {
             .callBatchBurn(
               [bobWallet.address, aliceWallet.address],
               [500, 1000],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Supply Modifier");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Supply Modifier');
       });
     });
 
-    describe("when specified identity has the SupplyModifier role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the SupplyModifier role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, aliceWallet, bobWallet, anotherWallet },
@@ -508,14 +510,14 @@ describe("AgentManager", () => {
             .callBatchBurn(
               [bobWallet.address, aliceWallet.address],
               [500, 100],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Supply Modifier");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Supply Modifier');
       });
     });
 
-    describe("when identity has the SupplyModifier role and the sender is authorized for it", () => {
-      it("Should perform the batch burn", async () => {
+    describe('when identity has the SupplyModifier role and the sender is authorized for it', () => {
+      it('Should perform the batch burn', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -531,22 +533,22 @@ describe("AgentManager", () => {
           .callBatchBurn(
             [bobWallet.address, aliceWallet.address],
             [500, 100],
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(burnTx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(bobWallet.address, ethers.constants.AddressZero, 500);
         await expect(burnTx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(aliceWallet.address, ethers.constants.AddressZero, 100);
       });
     });
   });
 
-  describe(".callSetAddressFrozen", () => {
-    describe("when specified identity is missing the Freezer role", () => {
-      it("Should revert", async () => {
+  describe('.callSetAddressFrozen', () => {
+    describe('when specified identity is missing the Freezer role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet },
@@ -559,14 +561,14 @@ describe("AgentManager", () => {
             .callSetAddressFrozen(
               aliceIdentity.address,
               true,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when specified identity has the Freezer role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the Freezer role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, anotherWallet },
@@ -583,14 +585,14 @@ describe("AgentManager", () => {
             .callSetAddressFrozen(
               aliceIdentity.address,
               true,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when identity has the Freezer role and the sender is authorized for it", () => {
-      it("Should perform the freeze", async () => {
+    describe('when identity has the Freezer role and the sender is authorized for it', () => {
+      it('Should perform the freeze', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet },
@@ -606,20 +608,20 @@ describe("AgentManager", () => {
           .callSetAddressFrozen(
             aliceWallet.address,
             true,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(tx)
-          .to.emit(token, "AddressFrozen")
+          .to.emit(token, 'AddressFrozen')
           .withArgs(aliceWallet.address, true, agentManager.address);
         await expect(token.isFrozen(aliceWallet.address)).to.eventually.be.true;
       });
     });
   });
 
-  describe(".callBatchSetAddressFrozen", () => {
-    describe("when specified identity is missing the Freezer role", () => {
-      it("Should revert", async () => {
+  describe('.callBatchSetAddressFrozen', () => {
+    describe('when specified identity is missing the Freezer role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -632,14 +634,14 @@ describe("AgentManager", () => {
             .callBatchSetAddressFrozen(
               [aliceIdentity.address, bobWallet.address],
               [true, false],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when specified identity has the Freezer role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the Freezer role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, bobWallet, anotherWallet },
@@ -656,14 +658,14 @@ describe("AgentManager", () => {
             .callBatchSetAddressFrozen(
               [aliceIdentity.address, bobWallet.address],
               [true, false],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when identity has the Freezer role and the sender is authorized for it", () => {
-      it("Should perform the batch pause", async () => {
+    describe('when identity has the Freezer role and the sender is authorized for it', () => {
+      it('Should perform the batch pause', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -679,22 +681,22 @@ describe("AgentManager", () => {
           .callBatchSetAddressFrozen(
             [aliceWallet.address, bobWallet.address],
             [true, false],
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(pauseTx)
-          .to.emit(token, "AddressFrozen")
+          .to.emit(token, 'AddressFrozen')
           .withArgs(aliceWallet.address, true, agentManager.address);
         await expect(pauseTx)
-          .to.emit(token, "AddressFrozen")
+          .to.emit(token, 'AddressFrozen')
           .withArgs(bobWallet.address, false, agentManager.address);
       });
     });
   });
 
-  describe(".callFreezePartialTokens", () => {
-    describe("when specified identity is missing the Freezer role", () => {
-      it("Should revert", async () => {
+  describe('.callFreezePartialTokens', () => {
+    describe('when specified identity is missing the Freezer role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet },
@@ -707,14 +709,14 @@ describe("AgentManager", () => {
             .callFreezePartialTokens(
               aliceIdentity.address,
               100,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when specified identity has the Freezer role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the Freezer role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, anotherWallet },
@@ -731,14 +733,14 @@ describe("AgentManager", () => {
             .callFreezePartialTokens(
               aliceIdentity.address,
               100,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when identity has the Freezer role and the sender is authorized for it", () => {
-      it("Should perform the freeze of partial tokens", async () => {
+    describe('when identity has the Freezer role and the sender is authorized for it', () => {
+      it('Should perform the freeze of partial tokens', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet },
@@ -754,19 +756,19 @@ describe("AgentManager", () => {
           .callFreezePartialTokens(
             aliceWallet.address,
             100,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(freezeTx)
-          .to.emit(token, "TokensFrozen")
+          .to.emit(token, 'TokensFrozen')
           .withArgs(aliceWallet.address, 100);
       });
     });
   });
 
-  describe(".callBatchFreezePartialTokens", () => {
-    describe("when specified identity is missing the Freezer role", () => {
-      it("Should revert", async () => {
+  describe('.callBatchFreezePartialTokens', () => {
+    describe('when specified identity is missing the Freezer role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -779,14 +781,14 @@ describe("AgentManager", () => {
             .callBatchFreezePartialTokens(
               [aliceWallet.address, bobWallet.address],
               [100, 200],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when specified identity has the Freezer role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the Freezer role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, aliceWallet, bobWallet, anotherWallet },
@@ -803,14 +805,14 @@ describe("AgentManager", () => {
             .callBatchFreezePartialTokens(
               [aliceWallet.address, bobWallet.address],
               [100, 200],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when identity has the Freezer role and the sender is authorized for it", () => {
-      it("Should perform the batch freeze of partial tokens", async () => {
+    describe('when identity has the Freezer role and the sender is authorized for it', () => {
+      it('Should perform the batch freeze of partial tokens', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -826,22 +828,22 @@ describe("AgentManager", () => {
           .callBatchFreezePartialTokens(
             [aliceWallet.address, bobWallet.address],
             [100, 200],
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(freezeTx)
-          .to.emit(token, "TokensFrozen")
+          .to.emit(token, 'TokensFrozen')
           .withArgs(aliceWallet.address, 100);
         await expect(freezeTx)
-          .to.emit(token, "TokensFrozen")
+          .to.emit(token, 'TokensFrozen')
           .withArgs(bobWallet.address, 200);
       });
     });
   });
 
-  describe(".callUnfreezePartialTokens", () => {
-    describe("when specified identity is missing the Freezer role", () => {
-      it("Should revert", async () => {
+  describe('.callUnfreezePartialTokens', () => {
+    describe('when specified identity is missing the Freezer role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet },
@@ -854,14 +856,14 @@ describe("AgentManager", () => {
             .callUnfreezePartialTokens(
               aliceIdentity.address,
               100,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when specified identity has the Freezer role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the Freezer role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, anotherWallet },
@@ -878,14 +880,14 @@ describe("AgentManager", () => {
             .callUnfreezePartialTokens(
               aliceIdentity.address,
               100,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when identity has the Freezer role and the sender is authorized for it", () => {
-      it("Should perform the unfreeze of partial tokens", async () => {
+    describe('when identity has the Freezer role and the sender is authorized for it', () => {
+      it('Should perform the unfreeze of partial tokens', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet },
@@ -901,7 +903,7 @@ describe("AgentManager", () => {
           .callFreezePartialTokens(
             aliceWallet.address,
             100,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         const freezeTx = await agentManager
@@ -909,19 +911,19 @@ describe("AgentManager", () => {
           .callUnfreezePartialTokens(
             aliceWallet.address,
             100,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(freezeTx)
-          .to.emit(token, "TokensUnfrozen")
+          .to.emit(token, 'TokensUnfrozen')
           .withArgs(aliceWallet.address, 100);
       });
     });
   });
 
-  describe(".callBatchUnfreezePartialTokens", () => {
-    describe("when specified identity is missing the Freezer role", () => {
-      it("Should revert", async () => {
+  describe('.callBatchUnfreezePartialTokens', () => {
+    describe('when specified identity is missing the Freezer role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -934,14 +936,14 @@ describe("AgentManager", () => {
             .callBatchUnfreezePartialTokens(
               [aliceWallet.address, bobWallet.address],
               [100, 200],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when specified identity has the Freezer role but the sender is not authorized for it", () => {
-      it("should revert", async () => {
+    describe('when specified identity has the Freezer role but the sender is not authorized for it', () => {
+      it('should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, aliceWallet, bobWallet, anotherWallet },
@@ -958,14 +960,14 @@ describe("AgentManager", () => {
             .callBatchUnfreezePartialTokens(
               [aliceWallet.address, bobWallet.address],
               [100, 200],
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Freezer");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Freezer');
       });
     });
 
-    describe("when identity has the Freezer role and the sender is authorized for it", () => {
-      it("Should perform the batch unfreeze of partial tokens", async () => {
+    describe('when identity has the Freezer role and the sender is authorized for it', () => {
+      it('Should perform the batch unfreeze of partial tokens', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -981,14 +983,14 @@ describe("AgentManager", () => {
           .callFreezePartialTokens(
             aliceWallet.address,
             100,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
         await agentManager
           .connect(aliceWallet)
           .callFreezePartialTokens(
             bobWallet.address,
             200,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         const freezeTx = await agentManager
@@ -996,19 +998,19 @@ describe("AgentManager", () => {
           .callBatchUnfreezePartialTokens(
             [aliceWallet.address, bobWallet.address],
             [100, 200],
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(freezeTx)
-          .to.emit(token, "TokensUnfrozen")
+          .to.emit(token, 'TokensUnfrozen')
           .withArgs(aliceWallet.address, 100);
       });
     });
   });
 
-  describe(".callRecoveryAddress", () => {
-    describe("when specified identity is missing the RecoveryAgent role", () => {
-      it("Should revert", async () => {
+  describe('.callRecoveryAddress', () => {
+    describe('when specified identity is missing the RecoveryAgent role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet, anotherWallet },
@@ -1022,14 +1024,14 @@ describe("AgentManager", () => {
               bobWallet.address,
               anotherWallet.address,
               bobIdentity.address,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Recovery Agent");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Recovery Agent');
       });
     });
 
-    describe("when specified identity has the RecoveryAgent role but sender is not authorized for it", () => {
-      it("Should revert", async () => {
+    describe('when specified identity has the RecoveryAgent role but sender is not authorized for it', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, bobWallet, anotherWallet },
@@ -1047,14 +1049,14 @@ describe("AgentManager", () => {
               bobWallet.address,
               anotherWallet.address,
               bobIdentity.address,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT Recovery Agent");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT Recovery Agent');
       });
     });
 
-    describe("when identity has the RecoveryAgent role and the sender is authorized for it", () => {
-      it("Should perform the recovery of the address", async () => {
+    describe('when identity has the RecoveryAgent role and the sender is authorized for it', () => {
+      it('Should perform the recovery of the address', async () => {
         const {
           suite: { agentManager, token },
           accounts: { tokenAdmin, aliceWallet, bobWallet, anotherWallet },
@@ -1070,12 +1072,12 @@ describe("AgentManager", () => {
           .addKey(
             ethers.utils.keccak256(
               ethers.utils.defaultAbiCoder.encode(
-                ["address"],
-                [anotherWallet.address]
-              )
+                ['address'],
+                [anotherWallet.address],
+              ),
             ),
             1,
-            1
+            1,
           );
 
         const recoveryTx = await agentManager
@@ -1084,23 +1086,23 @@ describe("AgentManager", () => {
             bobWallet.address,
             anotherWallet.address,
             bobIdentity.address,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(recoveryTx)
-          .to.emit(token, "RecoverySuccess")
+          .to.emit(token, 'RecoverySuccess')
           .withArgs(
             bobWallet.address,
             anotherWallet.address,
-            bobIdentity.address
+            bobIdentity.address,
           );
       });
     });
   });
 
-  describe(".callRegisterIdentity", () => {
-    describe("when specified identity is missing the WhiteListManager role", () => {
-      it("Should revert", async () => {
+  describe('.callRegisterIdentity', () => {
+    describe('when specified identity is missing the WhiteListManager role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -1114,14 +1116,14 @@ describe("AgentManager", () => {
               bobWallet.address,
               bobIdentity.address,
               42,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT WhiteList Manager");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT WhiteList Manager');
       });
     });
 
-    describe("when specified identity has the WhiteListManager role but sender is not authorized for it", () => {
-      it("Should revert", async () => {
+    describe('when specified identity has the WhiteListManager role but sender is not authorized for it', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, bobWallet },
@@ -1139,14 +1141,14 @@ describe("AgentManager", () => {
               bobWallet.address,
               bobIdentity.address,
               42,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT WhiteList Manager");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT WhiteList Manager');
       });
     });
 
-    describe("when identity has the WhitelistManager role and the sender is authorized for it", () => {
-      it("Should perform the registration of the identity", async () => {
+    describe('when identity has the WhitelistManager role and the sender is authorized for it', () => {
+      it('Should perform the registration of the identity', async () => {
         const {
           suite: { agentManager, identityRegistry },
           accounts: { tokenAdmin, aliceWallet, charlieWallet },
@@ -1163,11 +1165,11 @@ describe("AgentManager", () => {
             charlieWallet.address,
             charlieIdentity.address,
             42,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(registerTx)
-          .to.emit(identityRegistry, "IdentityRegistered")
+          .to.emit(identityRegistry, 'IdentityRegistered')
           .withArgs(charlieWallet.address, charlieIdentity.address);
 
         await expect(identityRegistry.contains(charlieWallet.address)).to
@@ -1176,9 +1178,9 @@ describe("AgentManager", () => {
     });
   });
 
-  describe(".callUpdateIdentity", () => {
-    describe("when specified identity is missing the WhiteListManager role", () => {
-      it("Should revert", async () => {
+  describe('.callUpdateIdentity', () => {
+    describe('when specified identity is missing the WhiteListManager role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -1191,14 +1193,14 @@ describe("AgentManager", () => {
             .callUpdateIdentity(
               bobWallet.address,
               bobIdentity.address,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT WhiteList Manager");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT WhiteList Manager');
       });
     });
 
-    describe("when specified identity has the WhiteListManager role but sender is not authorized for it", () => {
-      it("Should revert", async () => {
+    describe('when specified identity has the WhiteListManager role but sender is not authorized for it', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, bobWallet },
@@ -1215,14 +1217,14 @@ describe("AgentManager", () => {
             .callUpdateIdentity(
               bobWallet.address,
               bobIdentity.address,
-              aliceIdentity.address
-            )
-        ).to.be.revertedWith("Role: Sender is NOT WhiteList Manager");
+              aliceIdentity.address,
+            ),
+        ).to.be.revertedWith('Role: Sender is NOT WhiteList Manager');
       });
     });
 
-    describe("when identity has the WhitelistManager role and the sender is authorized for it", () => {
-      it("Should perform the update of the identity", async () => {
+    describe('when identity has the WhitelistManager role and the sender is authorized for it', () => {
+      it('Should perform the update of the identity', async () => {
         const {
           suite: { agentManager, identityRegistry },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -1238,19 +1240,19 @@ describe("AgentManager", () => {
           .callUpdateIdentity(
             bobWallet.address,
             charlieIdentity.address,
-            aliceIdentity.address
+            aliceIdentity.address,
           );
 
         await expect(updateTx)
-          .to.emit(identityRegistry, "IdentityUpdated")
+          .to.emit(identityRegistry, 'IdentityUpdated')
           .withArgs(bobIdentity.address, charlieIdentity.address);
       });
     });
   });
 
-  describe(".callUpdateCountry", () => {
-    describe("when specified identity is missing the WhiteListManager role", () => {
-      it("Should revert", async () => {
+  describe('.callUpdateCountry', () => {
+    describe('when specified identity is missing the WhiteListManager role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -1260,13 +1262,13 @@ describe("AgentManager", () => {
         await expect(
           agentManager
             .connect(aliceWallet)
-            .callUpdateCountry(bobWallet.address, 100, aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT WhiteList Manager");
+            .callUpdateCountry(bobWallet.address, 100, aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT WhiteList Manager');
       });
     });
 
-    describe("when specified identity has the WhiteListManager role but sender is not authorized for it", () => {
-      it("Should revert", async () => {
+    describe('when specified identity has the WhiteListManager role but sender is not authorized for it', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, bobWallet },
@@ -1280,13 +1282,13 @@ describe("AgentManager", () => {
         await expect(
           agentManager
             .connect(bobWallet)
-            .callUpdateCountry(bobWallet.address, 100, aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT WhiteList Manager");
+            .callUpdateCountry(bobWallet.address, 100, aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT WhiteList Manager');
       });
     });
 
-    describe("when identity has the WhitelistManager role and the sender is authorized for it", () => {
-      it("Should perform the update of the country", async () => {
+    describe('when identity has the WhitelistManager role and the sender is authorized for it', () => {
+      it('Should perform the update of the country', async () => {
         const {
           suite: { agentManager, identityRegistry },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -1302,15 +1304,15 @@ describe("AgentManager", () => {
           .callUpdateCountry(bobWallet.address, 100, aliceIdentity.address);
 
         await expect(updateTx)
-          .to.emit(identityRegistry, "CountryUpdated")
+          .to.emit(identityRegistry, 'CountryUpdated')
           .withArgs(bobWallet.address, 100);
       });
     });
   });
 
-  describe(".callDeleteIdentity", () => {
-    describe("when specified identity is missing the WhiteListManager role", () => {
-      it("Should revert", async () => {
+  describe('.callDeleteIdentity', () => {
+    describe('when specified identity is missing the WhiteListManager role', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { aliceWallet, bobWallet },
@@ -1320,13 +1322,13 @@ describe("AgentManager", () => {
         await expect(
           agentManager
             .connect(aliceWallet)
-            .callDeleteIdentity(bobWallet.address, aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT WhiteList Manager");
+            .callDeleteIdentity(bobWallet.address, aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT WhiteList Manager');
       });
     });
 
-    describe("when specified identity has the WhiteListManager role but sender is not authorized for it", () => {
-      it("Should revert", async () => {
+    describe('when specified identity has the WhiteListManager role but sender is not authorized for it', () => {
+      it('Should revert', async () => {
         const {
           suite: { agentManager },
           accounts: { tokenAdmin, bobWallet },
@@ -1340,13 +1342,13 @@ describe("AgentManager", () => {
         await expect(
           agentManager
             .connect(bobWallet)
-            .callDeleteIdentity(bobWallet.address, aliceIdentity.address)
-        ).to.be.revertedWith("Role: Sender is NOT WhiteList Manager");
+            .callDeleteIdentity(bobWallet.address, aliceIdentity.address),
+        ).to.be.revertedWith('Role: Sender is NOT WhiteList Manager');
       });
     });
 
-    describe("when identity has the WhitelistManager role and the sender is authorized for it", () => {
-      it("Should perform the deletion of the identity", async () => {
+    describe('when identity has the WhitelistManager role and the sender is authorized for it', () => {
+      it('Should perform the deletion of the identity', async () => {
         const {
           suite: { agentManager, identityRegistry },
           accounts: { tokenAdmin, aliceWallet, bobWallet },
@@ -1362,7 +1364,7 @@ describe("AgentManager", () => {
           .callDeleteIdentity(bobWallet.address, aliceIdentity.address);
 
         await expect(deleteTx)
-          .to.emit(identityRegistry, "IdentityRemoved")
+          .to.emit(identityRegistry, 'IdentityRemoved')
           .withArgs(bobWallet.address, bobIdentity.address);
 
         await expect(identityRegistry.contains(bobWallet.address)).to.eventually

--- a/test/agentRole.test.ts
+++ b/test/agentRole.test.ts
@@ -1,11 +1,11 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 async function deployAgentFixture() {
   const [ownerWallet, aliceWallet, bobWallet] = await ethers.getSigners();
 
-  const agentRole = await ethers.deployContract("AgentRole");
+  const agentRole = await ethers.deployContract('AgentRole');
 
   return {
     accounts: {
@@ -19,24 +19,24 @@ async function deployAgentFixture() {
   };
 }
 
-describe("AgentRole", () => {
-  describe(".addAgent", () => {
-    describe("when the sender is not the owner", () => {
-      it("should reverts", async () => {
+describe('AgentRole', () => {
+  describe('.addAgent', () => {
+    describe('when the sender is not the owner', () => {
+      it('should reverts', async () => {
         const {
           accounts: { aliceWallet, bobWallet },
           contracts: { agentRole },
         } = await loadFixture(deployAgentFixture);
 
         await expect(
-          agentRole.connect(bobWallet).addAgent(aliceWallet.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+          agentRole.connect(bobWallet).addAgent(aliceWallet.address),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("wgen the sender is the owner", () => {
-      describe("when address to add is the zero address", () => {
-        it("should reverts", async () => {
+    describe('wgen the sender is the owner', () => {
+      describe('when address to add is the zero address', () => {
+        it('should reverts', async () => {
           const {
             accounts: { ownerWallet },
             contracts: { agentRole },
@@ -45,14 +45,14 @@ describe("AgentRole", () => {
           await expect(
             agentRole
               .connect(ownerWallet)
-              .addAgent(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .addAgent(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when address to add is a valid address", () => {
-        describe("when address to add is already an agent", () => {
-          it("should reverts", async () => {
+      describe('when address to add is a valid address', () => {
+        describe('when address to add is already an agent', () => {
+          it('should reverts', async () => {
             const {
               accounts: { ownerWallet, aliceWallet },
               contracts: { agentRole },
@@ -60,13 +60,13 @@ describe("AgentRole", () => {
 
             await agentRole.connect(ownerWallet).addAgent(aliceWallet.address);
             await expect(
-              agentRole.connect(ownerWallet).addAgent(aliceWallet.address)
-            ).to.be.revertedWith("Roles: account already has role");
+              agentRole.connect(ownerWallet).addAgent(aliceWallet.address),
+            ).to.be.revertedWith('Roles: account already has role');
           });
         });
 
-        describe("when address to add is not an agent address", () => {
-          it("should add the agent", async () => {
+        describe('when address to add is not an agent address', () => {
+          it('should add the agent', async () => {
             const {
               accounts: { ownerWallet, aliceWallet },
               contracts: { agentRole },
@@ -76,7 +76,7 @@ describe("AgentRole", () => {
               .connect(ownerWallet)
               .addAgent(aliceWallet.address);
             await expect(tx)
-              .to.emit(agentRole, "AgentAdded")
+              .to.emit(agentRole, 'AgentAdded')
               .withArgs(aliceWallet.address);
             expect(await agentRole.isAgent(aliceWallet.address)).to.be.true;
           });
@@ -85,23 +85,23 @@ describe("AgentRole", () => {
     });
   });
 
-  describe(".removeAgent", () => {
-    describe("when the sender is not the owner", () => {
-      it("should reverts", async () => {
+  describe('.removeAgent', () => {
+    describe('when the sender is not the owner', () => {
+      it('should reverts', async () => {
         const {
           accounts: { aliceWallet, bobWallet },
           contracts: { agentRole },
         } = await loadFixture(deployAgentFixture);
 
         await expect(
-          agentRole.connect(bobWallet).removeAgent(aliceWallet.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+          agentRole.connect(bobWallet).removeAgent(aliceWallet.address),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("wgen the sender is the owner", () => {
-      describe("when address to add is the zero address", () => {
-        it("should reverts", async () => {
+    describe('wgen the sender is the owner', () => {
+      describe('when address to add is the zero address', () => {
+        it('should reverts', async () => {
           const {
             accounts: { ownerWallet },
             contracts: { agentRole },
@@ -110,27 +110,27 @@ describe("AgentRole", () => {
           await expect(
             agentRole
               .connect(ownerWallet)
-              .removeAgent(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .removeAgent(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when address to add is a valid address", () => {
-        describe("when address to add is not an agent", () => {
-          it("should reverts", async () => {
+      describe('when address to add is a valid address', () => {
+        describe('when address to add is not an agent', () => {
+          it('should reverts', async () => {
             const {
               accounts: { ownerWallet, aliceWallet },
               contracts: { agentRole },
             } = await loadFixture(deployAgentFixture);
 
             await expect(
-              agentRole.connect(ownerWallet).removeAgent(aliceWallet.address)
-            ).to.be.revertedWith("Roles: account does not have role");
+              agentRole.connect(ownerWallet).removeAgent(aliceWallet.address),
+            ).to.be.revertedWith('Roles: account does not have role');
           });
         });
 
-        describe("when address to add is an agent address", () => {
-          it("should remove the agent", async () => {
+        describe('when address to add is an agent address', () => {
+          it('should remove the agent', async () => {
             const {
               accounts: { ownerWallet, aliceWallet },
               contracts: { agentRole },
@@ -141,7 +141,7 @@ describe("AgentRole", () => {
               .connect(ownerWallet)
               .removeAgent(aliceWallet.address);
             await expect(tx)
-              .to.emit(agentRole, "AgentRemoved")
+              .to.emit(agentRole, 'AgentRemoved')
               .withArgs(aliceWallet.address);
             expect(await agentRole.isAgent(aliceWallet.address)).to.be.false;
           });

--- a/test/authorities/trex-implementation-authority.test.ts
+++ b/test/authorities/trex-implementation-authority.test.ts
@@ -1,13 +1,13 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
-import { deployFullSuiteFixture } from "../fixtures/deploy-full-suite.fixture";
+import { deployFullSuiteFixture } from '../fixtures/deploy-full-suite.fixture';
 
-describe("TrexImplementationAuthority", () => {
-  describe(".setTREXFactory()", () => {
-    describe("When not called by the owner", () => {
-      it("Should revert", async () => {
+describe('TrexImplementationAuthority', () => {
+  describe('.setTREXFactory()', () => {
+    describe('When not called by the owner', () => {
+      it('Should revert', async () => {
         const {
           authorities: { trexImplementationAuthority },
           accounts: { anotherWallet },
@@ -16,15 +16,15 @@ describe("TrexImplementationAuthority", () => {
         await expect(
           trexImplementationAuthority
             .connect(anotherWallet)
-            .setTREXFactory(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .setTREXFactory(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("When called by the owner", () => {
-      describe("When the authority has reference status true", () => {
-        describe("When the trex factory to add is not using this authority contract", () => {
-          it("Should revert for invalid link between the factory and the authority", async () => {
+    describe('When called by the owner', () => {
+      describe('When the authority has reference status true', () => {
+        describe('When the trex factory to add is not using this authority contract', () => {
+          it('Should revert for invalid link between the factory and the authority', async () => {
             const {
               accounts: { deployer },
               authorities: { trexImplementationAuthority },
@@ -33,13 +33,13 @@ describe("TrexImplementationAuthority", () => {
 
             const otherTrexImplementationAuthority =
               await ethers.deployContract(
-                "TREXImplementationAuthority",
+                'TREXImplementationAuthority',
                 [
                   true,
                   ethers.constants.AddressZero,
                   ethers.constants.AddressZero,
                 ],
-                deployer
+                deployer,
               );
             const versionStruct = {
               major: 4,
@@ -64,38 +64,38 @@ describe("TrexImplementationAuthority", () => {
               .addAndUseTREXVersion(versionStruct, contractsStruct);
 
             const trexFactory = await ethers.deployContract(
-              "TREXFactory",
+              'TREXFactory',
               [otherTrexImplementationAuthority.address],
-              deployer
+              deployer,
             );
 
             await expect(
-              trexImplementationAuthority.setTREXFactory(trexFactory.address)
-            ).to.be.revertedWith("only reference contract can call");
+              trexImplementationAuthority.setTREXFactory(trexFactory.address),
+            ).to.be.revertedWith('only reference contract can call');
           });
         });
 
-        describe("When the trex factory to add is using this authority contract", () => {
-          it("should set the trex factory address", async () => {
+        describe('When the trex factory to add is using this authority contract', () => {
+          it('should set the trex factory address', async () => {
             const {
               accounts: { deployer },
               authorities: { trexImplementationAuthority },
             } = await loadFixture(deployFullSuiteFixture);
 
             const trexFactory = await ethers.deployContract(
-              "TREXFactory",
+              'TREXFactory',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
 
             const tx = await trexImplementationAuthority.setTREXFactory(
-              trexFactory.address
+              trexFactory.address,
             );
             await expect(tx)
-              .to.emit(trexImplementationAuthority, "TREXFactorySet")
+              .to.emit(trexImplementationAuthority, 'TREXFactorySet')
               .withArgs(trexFactory.address);
             await expect(
-              trexImplementationAuthority.getTREXFactory()
+              trexImplementationAuthority.getTREXFactory(),
             ).to.eventually.equal(trexFactory.address);
           });
         });
@@ -103,9 +103,9 @@ describe("TrexImplementationAuthority", () => {
     });
   });
 
-  describe(".setIAFactory()", () => {
-    describe("When not called by the owner", () => {
-      it("Should revert", async () => {
+  describe('.setIAFactory()', () => {
+    describe('When not called by the owner', () => {
+      it('Should revert', async () => {
         const {
           authorities: { trexImplementationAuthority },
           accounts: { anotherWallet },
@@ -114,44 +114,44 @@ describe("TrexImplementationAuthority", () => {
         await expect(
           trexImplementationAuthority
             .connect(anotherWallet)
-            .setIAFactory(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .setIAFactory(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("When called by the owner", () => {
-      describe("When the authority has reference status true", () => {
-        describe("When the trex factory to add is using this authority contract", () => {
-          it("should set the trex factory address", async () => {
+    describe('When called by the owner', () => {
+      describe('When the authority has reference status true', () => {
+        describe('When the trex factory to add is using this authority contract', () => {
+          it('should set the trex factory address', async () => {
             const {
               accounts: { deployer },
               authorities: { trexImplementationAuthority },
             } = await loadFixture(deployFullSuiteFixture);
 
             const trexFactory = await ethers.deployContract(
-              "TREXFactory",
+              'TREXFactory',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
             await trexImplementationAuthority.setTREXFactory(
-              trexFactory.address
+              trexFactory.address,
             );
 
             const implementationAuthorityFactory = await ethers.deployContract(
-              "TREXImplementationAuthority",
+              'TREXImplementationAuthority',
               [
                 true,
                 ethers.constants.AddressZero,
                 ethers.constants.AddressZero,
               ],
-              deployer
+              deployer,
             );
 
             const tx = await trexImplementationAuthority.setIAFactory(
-              implementationAuthorityFactory.address
+              implementationAuthorityFactory.address,
             );
             await expect(tx)
-              .to.emit(trexImplementationAuthority, "IAFactorySet")
+              .to.emit(trexImplementationAuthority, 'IAFactorySet')
               .withArgs(implementationAuthorityFactory.address);
           });
         });
@@ -159,9 +159,9 @@ describe("TrexImplementationAuthority", () => {
     });
   });
 
-  describe(".fetchVersion()", () => {
-    describe("when called on the reference contract", () => {
-      it("should revert because the reference contract cannot fetch its own versions", async () => {
+  describe('.fetchVersion()', () => {
+    describe('when called on the reference contract', () => {
+      it('should revert because the reference contract cannot fetch its own versions', async () => {
         const {
           authorities: { trexImplementationAuthority },
         } = await loadFixture(deployFullSuiteFixture);
@@ -173,28 +173,28 @@ describe("TrexImplementationAuthority", () => {
         };
 
         await expect(
-          trexImplementationAuthority.fetchVersion(versionStruct)
-        ).to.be.revertedWith("cannot call on reference contract");
+          trexImplementationAuthority.fetchVersion(versionStruct),
+        ).to.be.revertedWith('cannot call on reference contract');
       });
     });
 
-    describe("when version were already fetched", () => {
-      it("should revert", async () => {
+    describe('when version were already fetched', () => {
+      it('should revert', async () => {
         const {
           accounts: { deployer },
           authorities: { trexImplementationAuthority },
         } = await loadFixture(deployFullSuiteFixture);
 
         const trexFactory = await ethers.deployContract(
-          "TREXFactory",
+          'TREXFactory',
           [trexImplementationAuthority.address],
-          deployer
+          deployer,
         );
 
         const otherTrexImplementationAuthority = await ethers.deployContract(
-          "TREXImplementationAuthority",
+          'TREXImplementationAuthority',
           [false, trexFactory.address, trexImplementationAuthority.address],
-          deployer
+          deployer,
         );
 
         const versionStruct = {
@@ -206,13 +206,13 @@ describe("TrexImplementationAuthority", () => {
         await otherTrexImplementationAuthority.fetchVersion(versionStruct);
 
         await expect(
-          otherTrexImplementationAuthority.fetchVersion(versionStruct)
-        ).to.be.revertedWith("version fetched already");
+          otherTrexImplementationAuthority.fetchVersion(versionStruct),
+        ).to.be.revertedWith('version fetched already');
       });
     });
 
-    describe("when version should be setup", () => {
-      it("should fetch and set the versions of the implementation from the reference contract", async () => {
+    describe('when version should be setup', () => {
+      it('should fetch and set the versions of the implementation from the reference contract', async () => {
         const {
           accounts: { deployer },
           authorities: { trexImplementationAuthority },
@@ -222,15 +222,15 @@ describe("TrexImplementationAuthority", () => {
         implementations;
 
         const trexFactory = await ethers.deployContract(
-          "TREXFactory",
+          'TREXFactory',
           [trexImplementationAuthority.address],
-          deployer
+          deployer,
         );
 
         const otherTrexImplementationAuthority = await ethers.deployContract(
-          "TREXImplementationAuthority",
+          'TREXImplementationAuthority',
           [false, trexFactory.address, trexImplementationAuthority.address],
-          deployer
+          deployer,
         );
 
         const versionStruct = {
@@ -240,19 +240,19 @@ describe("TrexImplementationAuthority", () => {
         };
 
         const tx = await otherTrexImplementationAuthority.fetchVersion(
-          versionStruct
+          versionStruct,
         );
         expect(tx).to.emit(
           otherTrexImplementationAuthority,
-          "TREXVersionFetched"
+          'TREXVersionFetched',
         );
       });
     });
   });
 
-  describe(".addTREXVersion()", () => {
-    describe("when called not as owner", () => {
-      it("should revert", async () => {
+  describe('.addTREXVersion()', () => {
+    describe('when called not as owner', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           authorities: { trexImplementationAuthority },
@@ -280,14 +280,14 @@ describe("TrexImplementationAuthority", () => {
         await expect(
           trexImplementationAuthority
             .connect(anotherWallet)
-            .addTREXVersion(versionStruct, contractsStruct)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .addTREXVersion(versionStruct, contractsStruct),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when called as owner", () => {
-      describe("when called on a non-reference contract", () => {
-        it("should revert", async () => {
+    describe('when called as owner', () => {
+      describe('when called on a non-reference contract', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             authorities: { trexImplementationAuthority },
@@ -295,15 +295,15 @@ describe("TrexImplementationAuthority", () => {
           } = await loadFixture(deployFullSuiteFixture);
 
           const trexFactory = await ethers.deployContract(
-            "TREXFactory",
+            'TREXFactory',
             [trexImplementationAuthority.address],
-            deployer
+            deployer,
           );
 
           const otherTrexImplementationAuthority = await ethers.deployContract(
-            "TREXImplementationAuthority",
+            'TREXImplementationAuthority',
             [false, trexFactory.address, trexImplementationAuthority.address],
-            deployer
+            deployer,
           );
 
           const versionStruct = {
@@ -328,15 +328,15 @@ describe("TrexImplementationAuthority", () => {
           await expect(
             otherTrexImplementationAuthority.addTREXVersion(
               versionStruct,
-              contractsStruct
-            )
-          ).to.be.revertedWith("ONLY reference contract can add versions");
+              contractsStruct,
+            ),
+          ).to.be.revertedWith('ONLY reference contract can add versions');
         });
       });
 
-      describe("when called on a reference contract", () => {
-        describe("when version were already added", () => {
-          it("should revert", async () => {
+      describe('when called on a reference contract', () => {
+        describe('when version were already added', () => {
+          it('should revert', async () => {
             const {
               authorities: { trexImplementationAuthority },
               implementations,
@@ -364,14 +364,14 @@ describe("TrexImplementationAuthority", () => {
             await expect(
               trexImplementationAuthority.addTREXVersion(
                 versionStruct,
-                contractsStruct
-              )
-            ).to.be.revertedWith("version already exists");
+                contractsStruct,
+              ),
+            ).to.be.revertedWith('version already exists');
           });
         });
 
-        describe("when a contract implementation address is the zero address", () => {
-          it("should revert", async () => {
+        describe('when a contract implementation address is the zero address', () => {
+          it('should revert', async () => {
             const {
               authorities: { trexImplementationAuthority },
               implementations,
@@ -398,18 +398,18 @@ describe("TrexImplementationAuthority", () => {
             await expect(
               trexImplementationAuthority.addTREXVersion(
                 versionStruct,
-                contractsStruct
-              )
-            ).to.be.revertedWith("invalid argument - zero address");
+                contractsStruct,
+              ),
+            ).to.be.revertedWith('invalid argument - zero address');
           });
         });
       });
     });
   });
 
-  describe(".useTREXVersion()", () => {
-    describe("when called not as owner", () => {
-      it("should revert", async () => {
+  describe('.useTREXVersion()', () => {
+    describe('when called not as owner', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           authorities: { trexImplementationAuthority },
@@ -424,14 +424,14 @@ describe("TrexImplementationAuthority", () => {
         await expect(
           trexImplementationAuthority
             .connect(anotherWallet)
-            .useTREXVersion(versionStruct)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .useTREXVersion(versionStruct),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when called as owner", () => {
-      describe("when version is already in use", () => {
-        it("should revert", async () => {
+    describe('when called as owner', () => {
+      describe('when version is already in use', () => {
+        it('should revert', async () => {
           const {
             authorities: { trexImplementationAuthority },
           } = await loadFixture(deployFullSuiteFixture);
@@ -443,13 +443,13 @@ describe("TrexImplementationAuthority", () => {
           };
 
           await expect(
-            trexImplementationAuthority.useTREXVersion(versionStruct)
-          ).to.be.revertedWith("version already in use");
+            trexImplementationAuthority.useTREXVersion(versionStruct),
+          ).to.be.revertedWith('version already in use');
         });
       });
 
-      describe("when version does not exist", () => {
-        it("should revert", async () => {
+      describe('when version does not exist', () => {
+        it('should revert', async () => {
           const {
             authorities: { trexImplementationAuthority },
           } = await loadFixture(deployFullSuiteFixture);
@@ -461,16 +461,16 @@ describe("TrexImplementationAuthority", () => {
           };
 
           await expect(
-            trexImplementationAuthority.useTREXVersion(versionStruct)
-          ).to.be.revertedWith("invalid argument - non existing version");
+            trexImplementationAuthority.useTREXVersion(versionStruct),
+          ).to.be.revertedWith('invalid argument - non existing version');
         });
       });
     });
   });
 
-  describe(".changeImplementationAuthority()", () => {
-    describe("when token to update is the zero address", () => {
-      it("should revert", async () => {
+  describe('.changeImplementationAuthority()', () => {
+    describe('when token to update is the zero address', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           authorities: { trexImplementationAuthority },
@@ -479,15 +479,15 @@ describe("TrexImplementationAuthority", () => {
         await expect(
           trexImplementationAuthority.changeImplementationAuthority(
             ethers.constants.AddressZero,
-            anotherWallet.address
-          )
-        ).to.be.revertedWith("invalid argument - zero address");
+            anotherWallet.address,
+          ),
+        ).to.be.revertedWith('invalid argument - zero address');
       });
     });
 
-    describe("whe new authority is the zero address", () => {
-      describe("when called on a non-reference authority contract", () => {
-        it("should revert", async () => {
+    describe('whe new authority is the zero address', () => {
+      describe('when called on a non-reference authority contract', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             authorities: { trexImplementationAuthority },
@@ -495,29 +495,29 @@ describe("TrexImplementationAuthority", () => {
           } = await loadFixture(deployFullSuiteFixture);
 
           const trexFactory = await ethers.deployContract(
-            "TREXFactory",
+            'TREXFactory',
             [trexImplementationAuthority.address],
-            deployer
+            deployer,
           );
 
           const otherTrexImplementationAuthority = await ethers.deployContract(
-            "TREXImplementationAuthority",
+            'TREXImplementationAuthority',
             [false, trexFactory.address, trexImplementationAuthority.address],
-            deployer
+            deployer,
           );
 
           await expect(
             otherTrexImplementationAuthority.changeImplementationAuthority(
               token.address,
-              ethers.constants.AddressZero
-            )
-          ).to.be.revertedWith("only reference contract can deploy new IAs");
+              ethers.constants.AddressZero,
+            ),
+          ).to.be.revertedWith('only reference contract can deploy new IAs');
         });
       });
 
-      describe("when called on a reference authority contract", () => {
-        describe("when caller is not owner of the token (or any contract of the suite)", () => {
-          it("should revert", async () => {
+      describe('when called on a reference authority contract', () => {
+        describe('when caller is not owner of the token (or any contract of the suite)', () => {
+          it('should revert', async () => {
             const {
               accounts: { anotherWallet },
               authorities: { trexImplementationAuthority },
@@ -529,14 +529,14 @@ describe("TrexImplementationAuthority", () => {
                 .connect(anotherWallet)
                 .changeImplementationAuthority(
                   token.address,
-                  ethers.constants.AddressZero
-                )
-            ).to.be.revertedWith("caller NOT owner of all contracts impacted");
+                  ethers.constants.AddressZero,
+                ),
+            ).to.be.revertedWith('caller NOT owner of all contracts impacted');
           });
         });
 
-        describe("when caller is owner of every contract of the suite of the token", () => {
-          it("should deploy a new authority contract", async () => {
+        describe('when caller is owner of every contract of the suite of the token', () => {
+          it('should deploy a new authority contract', async () => {
             const {
               accounts: { deployer },
               authorities: { trexImplementationAuthority },
@@ -544,48 +544,48 @@ describe("TrexImplementationAuthority", () => {
             } = await loadFixture(deployFullSuiteFixture);
 
             const compliance = await ethers.deployContract(
-              "ModularComplianceProxy",
+              'ModularComplianceProxy',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
             await token.setCompliance(compliance.address);
 
             const trexFactory = await ethers.deployContract(
-              "TREXFactory",
+              'TREXFactory',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
 
             const implementationAuthorityFactory = await ethers.deployContract(
-              "IAFactory",
+              'IAFactory',
               [trexFactory.address],
-              deployer
+              deployer,
             );
             await trexImplementationAuthority.setTREXFactory(
-              trexFactory.address
+              trexFactory.address,
             );
             await trexImplementationAuthority.setIAFactory(
-              implementationAuthorityFactory.address
+              implementationAuthorityFactory.address,
             );
 
             const tx =
               await trexImplementationAuthority.changeImplementationAuthority(
                 token.address,
-                ethers.constants.AddressZero
+                ethers.constants.AddressZero,
               );
             expect(tx).to.emit(
               trexImplementationAuthority,
-              "ImplementationAuthorityChanged"
+              'ImplementationAuthorityChanged',
             );
           });
         });
       });
     });
 
-    describe("when new authority is not the zero address", () => {
-      describe("when caller is owner of every contract of the suite of the token", () => {
-        describe("when version used by the reference contract is not the same as currently deployed implementations", () => {
-          it("should revert", async () => {
+    describe('when new authority is not the zero address', () => {
+      describe('when caller is owner of every contract of the suite of the token', () => {
+        describe('when version used by the reference contract is not the same as currently deployed implementations', () => {
+          it('should revert', async () => {
             const {
               accounts: { deployer },
               authorities: { trexImplementationAuthority },
@@ -594,39 +594,39 @@ describe("TrexImplementationAuthority", () => {
             } = await loadFixture(deployFullSuiteFixture);
 
             const compliance = await ethers.deployContract(
-              "ModularComplianceProxy",
+              'ModularComplianceProxy',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
             await token.setCompliance(compliance.address);
 
             const trexFactory = await ethers.deployContract(
-              "TREXFactory",
+              'TREXFactory',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
 
             const implementationAuthorityFactory = await ethers.deployContract(
-              "IAFactory",
+              'IAFactory',
               [trexFactory.address],
-              deployer
+              deployer,
             );
             await trexImplementationAuthority.setTREXFactory(
-              trexFactory.address
+              trexFactory.address,
             );
             await trexImplementationAuthority.setIAFactory(
-              implementationAuthorityFactory.address
+              implementationAuthorityFactory.address,
             );
 
             const otherTrexImplementationAuthority =
               await ethers.deployContract(
-                "TREXImplementationAuthority",
+                'TREXImplementationAuthority',
                 [
                   true,
                   trexFactory.address,
                   trexImplementationAuthority.address,
                 ],
-                deployer
+                deployer,
               );
             await otherTrexImplementationAuthority.addAndUseTREXVersion(
               { major: 4, minor: 0, patch: 1 },
@@ -643,22 +643,22 @@ describe("TrexImplementationAuthority", () => {
                   implementations.trustedIssuersRegistryImplementation.address,
                 mcImplementation:
                   implementations.modularComplianceImplementation.address,
-              }
+              },
             );
 
             await expect(
               trexImplementationAuthority.changeImplementationAuthority(
                 token.address,
-                otherTrexImplementationAuthority.address
-              )
+                otherTrexImplementationAuthority.address,
+              ),
             ).to.be.revertedWith(
-              "version of new IA has to be the same as current IA"
+              'version of new IA has to be the same as current IA',
             );
           });
         });
 
-        describe("when the new implementation authority is a reference contract but not the current one", () => {
-          it("should revert", async () => {
+        describe('when the new implementation authority is a reference contract but not the current one', () => {
+          it('should revert', async () => {
             const {
               accounts: { deployer },
               authorities: { trexImplementationAuthority },
@@ -667,39 +667,39 @@ describe("TrexImplementationAuthority", () => {
             } = await loadFixture(deployFullSuiteFixture);
 
             const compliance = await ethers.deployContract(
-              "ModularComplianceProxy",
+              'ModularComplianceProxy',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
             await token.setCompliance(compliance.address);
 
             const trexFactory = await ethers.deployContract(
-              "TREXFactory",
+              'TREXFactory',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
 
             const implementationAuthorityFactory = await ethers.deployContract(
-              "IAFactory",
+              'IAFactory',
               [trexFactory.address],
-              deployer
+              deployer,
             );
             await trexImplementationAuthority.setTREXFactory(
-              trexFactory.address
+              trexFactory.address,
             );
             await trexImplementationAuthority.setIAFactory(
-              implementationAuthorityFactory.address
+              implementationAuthorityFactory.address,
             );
 
             const otherTrexImplementationAuthority =
               await ethers.deployContract(
-                "TREXImplementationAuthority",
+                'TREXImplementationAuthority',
                 [
                   true,
                   trexFactory.address,
                   trexImplementationAuthority.address,
                 ],
-                deployer
+                deployer,
               );
             await otherTrexImplementationAuthority.addAndUseTREXVersion(
               { major: 4, minor: 0, patch: 0 },
@@ -716,20 +716,20 @@ describe("TrexImplementationAuthority", () => {
                   implementations.trustedIssuersRegistryImplementation.address,
                 mcImplementation:
                   implementations.modularComplianceImplementation.address,
-              }
+              },
             );
 
             await expect(
               trexImplementationAuthority.changeImplementationAuthority(
                 token.address,
-                otherTrexImplementationAuthority.address
-              )
-            ).to.be.revertedWith("new IA is NOT reference contract");
+                otherTrexImplementationAuthority.address,
+              ),
+            ).to.be.revertedWith('new IA is NOT reference contract');
           });
         });
 
-        describe("when the new implementation authority is not a reference contract and is not valid", () => {
-          it("should revert", async () => {
+        describe('when the new implementation authority is not a reference contract and is not valid', () => {
+          it('should revert', async () => {
             const {
               accounts: { deployer },
               authorities: { trexImplementationAuthority },
@@ -737,39 +737,39 @@ describe("TrexImplementationAuthority", () => {
             } = await loadFixture(deployFullSuiteFixture);
 
             const compliance = await ethers.deployContract(
-              "ModularComplianceProxy",
+              'ModularComplianceProxy',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
             await token.setCompliance(compliance.address);
 
             const trexFactory = await ethers.deployContract(
-              "TREXFactory",
+              'TREXFactory',
               [trexImplementationAuthority.address],
-              deployer
+              deployer,
             );
 
             const implementationAuthorityFactory = await ethers.deployContract(
-              "IAFactory",
+              'IAFactory',
               [trexFactory.address],
-              deployer
+              deployer,
             );
             await trexImplementationAuthority.setTREXFactory(
-              trexFactory.address
+              trexFactory.address,
             );
             await trexImplementationAuthority.setIAFactory(
-              implementationAuthorityFactory.address
+              implementationAuthorityFactory.address,
             );
 
             const otherTrexImplementationAuthority =
               await ethers.deployContract(
-                "TREXImplementationAuthority",
+                'TREXImplementationAuthority',
                 [
                   false,
                   trexFactory.address,
                   trexImplementationAuthority.address,
                 ],
-                deployer
+                deployer,
               );
             await otherTrexImplementationAuthority.fetchVersion({
               major: 4,
@@ -785,9 +785,9 @@ describe("TrexImplementationAuthority", () => {
             await expect(
               trexImplementationAuthority.changeImplementationAuthority(
                 token.address,
-                otherTrexImplementationAuthority.address
-              )
-            ).to.be.revertedWith("invalid IA");
+                otherTrexImplementationAuthority.address,
+              ),
+            ).to.be.revertedWith('invalid IA');
           });
         });
       });

--- a/test/compliance.test.ts
+++ b/test/compliance.test.ts
@@ -1,156 +1,156 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 import {
   deployFullSuiteFixture,
   deploySuiteWithModularCompliancesFixture,
   deploySuiteWithModuleComplianceBoundToWallet,
-} from "./fixtures/deploy-full-suite.fixture";
+} from './fixtures/deploy-full-suite.fixture';
 
-describe("ModularCompliance", () => {
-  describe(".init", () => {
-    it("should prevent calling init twice", async () => {
+describe('ModularCompliance', () => {
+  describe('.init', () => {
+    it('should prevent calling init twice', async () => {
       const {
         suite: { compliance },
       } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
       await expect(compliance.init()).to.be.revertedWith(
-        "Initializable: contract is already initialized"
+        'Initializable: contract is already initialized',
       );
     });
   });
 
-  describe(".bindToken", () => {
-    describe("when calling as another account that the owner", () => {
-      it("should revert", async () => {
+  describe('.bindToken', () => {
+    describe('when calling as another account that the owner', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           suite: { token, compliance },
         } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
         await expect(
-          compliance.connect(anotherWallet).bindToken(token.address)
-        ).to.be.revertedWith("only owner or token can call");
+          compliance.connect(anotherWallet).bindToken(token.address),
+        ).to.be.revertedWith('only owner or token can call');
       });
     });
 
-    describe("when the compliance is already bound to a token", () => {
-      describe("when not calling as the token", () => {
-        it("should revert", async () => {
+    describe('when the compliance is already bound to a token', () => {
+      describe('when not calling as the token', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer, anotherWallet },
             suite: { token },
           } = await loadFixture(deployFullSuiteFixture);
 
           const compliance = await ethers.deployContract(
-            "ModularCompliance",
-            deployer
+            'ModularCompliance',
+            deployer,
           );
           await compliance.init();
 
           await compliance.bindToken(token.address);
 
           await expect(
-            compliance.connect(anotherWallet).bindToken(token.address)
-          ).to.be.revertedWith("only owner or token can call");
+            compliance.connect(anotherWallet).bindToken(token.address),
+          ).to.be.revertedWith('only owner or token can call');
         });
       });
 
-      describe("when calling as the token", () => {
-        it("should set the new compliance", async () => {
+      describe('when calling as the token', () => {
+        it('should set the new compliance', async () => {
           const {
             suite: { token },
           } = await loadFixture(deployFullSuiteFixture);
 
-          const compliance = await ethers.deployContract("ModularCompliance");
+          const compliance = await ethers.deployContract('ModularCompliance');
           await compliance.init();
           await compliance.bindToken(token.address);
 
           const newCompliance = await ethers.deployContract(
-            "ModularCompliance"
+            'ModularCompliance',
           );
 
           const tx = await token.setCompliance(newCompliance.address);
           await expect(tx)
-            .to.emit(token, "ComplianceAdded")
+            .to.emit(token, 'ComplianceAdded')
             .withArgs(newCompliance.address);
           await expect(tx)
-            .to.emit(newCompliance, "TokenBound")
+            .to.emit(newCompliance, 'TokenBound')
             .withArgs(token.address);
         });
       });
     });
 
-    describe("when calling as the owner", () => {
-      describe("when token address is zero", () => {
-        it("should revert", async () => {
+    describe('when calling as the owner', () => {
+      describe('when token address is zero', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
           } = await loadFixture(deployFullSuiteFixture);
 
           const compliance = await ethers.deployContract(
-            "ModularCompliance",
-            deployer
+            'ModularCompliance',
+            deployer,
           );
           await compliance.init();
 
           await expect(
-            compliance.bindToken(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+            compliance.bindToken(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
     });
   });
 
-  describe(".unbindToken", () => {
-    describe("when calling as another account", () => {
-      it("should revert", async () => {
+  describe('.unbindToken', () => {
+    describe('when calling as another account', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           suite: { token, compliance },
         } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
         await expect(
-          compliance.connect(anotherWallet).unbindToken(token.address)
-        ).to.be.revertedWith("only owner or token can call");
+          compliance.connect(anotherWallet).unbindToken(token.address),
+        ).to.be.revertedWith('only owner or token can call');
       });
     });
 
-    describe("when calling as the owner", () => {
-      describe("when token is a zero address", () => {
-        it("should revert", async () => {
+    describe('when calling as the owner', () => {
+      describe('when token is a zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
           } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
           await expect(
-            compliance.unbindToken(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+            compliance.unbindToken(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when token is not bound", () => {
-        it("should revert", async () => {
+      describe('when token is not bound', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             suite: { token },
           } = await loadFixture(deployFullSuiteFixture);
 
           const compliance = await ethers.deployContract(
-            "ModularCompliance",
-            deployer
+            'ModularCompliance',
+            deployer,
           );
           await compliance.init();
 
           await expect(
-            compliance.unbindToken(token.address)
-          ).to.be.revertedWith("This token is not bound");
+            compliance.unbindToken(token.address),
+          ).to.be.revertedWith('This token is not bound');
         });
       });
     });
 
-    describe("when calling as the token given in parameters", () => {
-      it("should bind the new compliance to the token", async () => {
+    describe('when calling as the token given in parameters', () => {
+      it('should bind the new compliance to the token', async () => {
         const {
           suite: { compliance, complianceBeta, token },
         } = await loadFixture(deploySuiteWithModularCompliancesFixture);
@@ -159,25 +159,25 @@ describe("ModularCompliance", () => {
 
         const tx = await token.setCompliance(complianceBeta.address);
         await expect(tx)
-          .to.emit(token, "ComplianceAdded")
+          .to.emit(token, 'ComplianceAdded')
           .withArgs(complianceBeta.address);
         await expect(tx)
-          .to.emit(complianceBeta, "TokenBound")
+          .to.emit(complianceBeta, 'TokenBound')
           .withArgs(token.address);
         await expect(tx)
-          .to.emit(compliance, "TokenUnbound")
+          .to.emit(compliance, 'TokenUnbound')
           .withArgs(token.address);
 
         await expect(complianceBeta.getTokenBound()).to.eventually.eq(
-          token.address
+          token.address,
         );
       });
     });
   });
 
-  describe(".addModule", () => {
-    describe("when not calling as the owner", () => {
-      it("should revert", async () => {
+  describe('.addModule', () => {
+    describe('when not calling as the owner', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           suite: { compliance },
@@ -186,50 +186,50 @@ describe("ModularCompliance", () => {
         await expect(
           compliance
             .connect(anotherWallet)
-            .addModule(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .addModule(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when calling as the owner", () => {
-      describe("when module address is zero", () => {
-        it("should revert", async () => {
+    describe('when calling as the owner', () => {
+      describe('when module address is zero', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
           } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
           await expect(
-            compliance.addModule(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+            compliance.addModule(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when module address is already bound", () => {
-        it("should revert", async () => {
+      describe('when module address is already bound', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
           } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
-          const module = await ethers.deployContract("CountryAllowModule");
+          const module = await ethers.deployContract('CountryAllowModule');
           await compliance.addModule(module.address);
 
           await expect(compliance.addModule(module.address)).to.be.revertedWith(
-            "module already bound"
+            'module already bound',
           );
         });
       });
 
-      describe("when adding a module", () => {
-        it("should add the module", async () => {
+      describe('when adding a module', () => {
+        it('should add the module', async () => {
           const {
             suite: { compliance },
           } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
-          const module = await ethers.deployContract("CountryAllowModule");
+          const module = await ethers.deployContract('CountryAllowModule');
           const tx = await compliance.addModule(module.address);
 
           await expect(tx)
-            .to.emit(compliance, "ModuleAdded")
+            .to.emit(compliance, 'ModuleAdded')
             .withArgs(module.address);
           await expect(compliance.getModules()).to.eventually.deep.eq([
             module.address,
@@ -237,35 +237,35 @@ describe("ModularCompliance", () => {
         });
       });
 
-      describe("when attempting to bind a 25th module", () => {
-        it("should revert", async () => {
+      describe('when attempting to bind a 25th module', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
           } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
           const modules = await Promise.all(
             Array.from({ length: 25 }, () =>
-              ethers.deployContract("CountryAllowModule")
-            )
+              ethers.deployContract('CountryAllowModule'),
+            ),
           );
 
           await Promise.all(
-            modules.map((module) => compliance.addModule(module.address))
+            modules.map((module) => compliance.addModule(module.address)),
           );
 
-          const module = await ethers.deployContract("CountryAllowModule");
+          const module = await ethers.deployContract('CountryAllowModule');
 
           await expect(compliance.addModule(module.address)).to.be.revertedWith(
-            "cannot add more than 25 modules"
+            'cannot add more than 25 modules',
           );
         });
       });
     });
   });
 
-  describe(".removeModule", () => {
-    describe("when not calling as owner", () => {
-      it("should revert", async () => {
+  describe('.removeModule', () => {
+    describe('when not calling as owner', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           suite: { compliance },
@@ -274,54 +274,54 @@ describe("ModularCompliance", () => {
         await expect(
           compliance
             .connect(anotherWallet)
-            .removeModule(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .removeModule(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when calling as the owner", () => {
-      describe("when module address is zero", () => {
-        it("should revert", async () => {
+    describe('when calling as the owner', () => {
+      describe('when module address is zero', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
           } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
           await expect(
-            compliance.removeModule(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+            compliance.removeModule(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when module address is not bound", () => {
-        it("should revert", async () => {
+      describe('when module address is not bound', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
           } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
-          const module = await ethers.deployContract("CountryAllowModule");
+          const module = await ethers.deployContract('CountryAllowModule');
 
           await expect(
-            compliance.removeModule(module.address)
-          ).to.be.revertedWith("module not bound");
+            compliance.removeModule(module.address),
+          ).to.be.revertedWith('module not bound');
         });
       });
 
-      describe("when module is bound", () => {
-        it("should remove the module", async () => {
+      describe('when module is bound', () => {
+        it('should remove the module', async () => {
           const {
             suite: { compliance },
           } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
-          const module = await ethers.deployContract("CountryAllowModule");
+          const module = await ethers.deployContract('CountryAllowModule');
           await compliance.addModule(module.address);
 
-          const moduleB = await ethers.deployContract("CountryAllowModule");
+          const moduleB = await ethers.deployContract('CountryAllowModule');
           await compliance.addModule(moduleB.address);
 
           const tx = await compliance.removeModule(moduleB.address);
 
           await expect(tx)
-            .to.emit(compliance, "ModuleRemoved")
+            .to.emit(compliance, 'ModuleRemoved')
             .withArgs(moduleB.address);
 
           await expect(compliance.isModuleBound(moduleB.address)).to.be
@@ -331,9 +331,9 @@ describe("ModularCompliance", () => {
     });
   });
 
-  describe(".transferred", () => {
-    describe("when not calling as a bound token", () => {
-      it("should revert", async () => {
+  describe('.transferred', () => {
+    describe('when not calling as a bound token', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           suite: { compliance },
@@ -345,17 +345,17 @@ describe("ModularCompliance", () => {
             .transferred(
               ethers.constants.AddressZero,
               ethers.constants.AddressZero,
-              0
-            )
+              0,
+            ),
         ).to.be.revertedWith(
-          "error : this address is not a token bound to the compliance contract"
+          'error : this address is not a token bound to the compliance contract',
         );
       });
     });
 
-    describe("when calling as a bound token", () => {
-      describe("when from address is null", () => {
-        it("should revert", async () => {
+    describe('when calling as a bound token', () => {
+      describe('when from address is null', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
             accounts: { bobWallet, charlieWallet },
@@ -364,13 +364,13 @@ describe("ModularCompliance", () => {
           await expect(
             compliance
               .connect(charlieWallet)
-              .transferred(ethers.constants.AddressZero, bobWallet.address, 10)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .transferred(ethers.constants.AddressZero, bobWallet.address, 10),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when to address is null", () => {
-        it("should revert", async () => {
+      describe('when to address is null', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
             accounts: { charlieWallet, aliceWallet },
@@ -382,14 +382,14 @@ describe("ModularCompliance", () => {
               .transferred(
                 aliceWallet.address,
                 ethers.constants.AddressZero,
-                10
-              )
-          ).to.be.revertedWith("invalid argument - zero address");
+                10,
+              ),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when amount is zero", () => {
-        it("should revert", async () => {
+      describe('when amount is zero', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
             accounts: { aliceWallet, bobWallet, charlieWallet },
@@ -398,13 +398,13 @@ describe("ModularCompliance", () => {
           await expect(
             compliance
               .connect(charlieWallet)
-              .transferred(aliceWallet.address, bobWallet.address, 0)
-          ).to.be.revertedWith("invalid argument - no value transfer");
+              .transferred(aliceWallet.address, bobWallet.address, 0),
+          ).to.be.revertedWith('invalid argument - no value transfer');
         });
       });
 
-      describe("when amount is greater than zero", () => {
-        it("Should update the modules", async () => {
+      describe('when amount is greater than zero', () => {
+        it('Should update the modules', async () => {
           const {
             suite: { compliance },
             accounts: { aliceWallet, bobWallet, charlieWallet },
@@ -413,16 +413,16 @@ describe("ModularCompliance", () => {
           await expect(
             compliance
               .connect(charlieWallet)
-              .transferred(aliceWallet.address, bobWallet.address, 10)
+              .transferred(aliceWallet.address, bobWallet.address, 10),
           ).to.be.fulfilled;
         });
       });
     });
   });
 
-  describe(".created", () => {
-    describe("when not calling as a bound token", () => {
-      it("should revert", async () => {
+  describe('.created', () => {
+    describe('when not calling as a bound token', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           suite: { compliance },
@@ -431,16 +431,16 @@ describe("ModularCompliance", () => {
         await expect(
           compliance
             .connect(anotherWallet)
-            .created(ethers.constants.AddressZero, 0)
+            .created(ethers.constants.AddressZero, 0),
         ).to.be.revertedWith(
-          "error : this address is not a token bound to the compliance contract"
+          'error : this address is not a token bound to the compliance contract',
         );
       });
     });
 
-    describe("when calling as a bound token", () => {
-      describe("when to address is null", () => {
-        it("should revert", async () => {
+    describe('when calling as a bound token', () => {
+      describe('when to address is null', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
             accounts: { charlieWallet },
@@ -449,42 +449,42 @@ describe("ModularCompliance", () => {
           await expect(
             compliance
               .connect(charlieWallet)
-              .created(ethers.constants.AddressZero, 10)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .created(ethers.constants.AddressZero, 10),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when amount is zero", () => {
-        it("should revert", async () => {
+      describe('when amount is zero', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
             accounts: { bobWallet, charlieWallet },
           } = await loadFixture(deploySuiteWithModuleComplianceBoundToWallet);
 
           await expect(
-            compliance.connect(charlieWallet).created(bobWallet.address, 0)
-          ).to.be.revertedWith("invalid argument - no value mint");
+            compliance.connect(charlieWallet).created(bobWallet.address, 0),
+          ).to.be.revertedWith('invalid argument - no value mint');
         });
       });
 
-      describe("when amount is greater than zero", () => {
-        it("Should update the modules", async () => {
+      describe('when amount is greater than zero', () => {
+        it('Should update the modules', async () => {
           const {
             suite: { compliance },
             accounts: { bobWallet, charlieWallet },
           } = await loadFixture(deploySuiteWithModuleComplianceBoundToWallet);
 
           await expect(
-            compliance.connect(charlieWallet).created(bobWallet.address, 10)
+            compliance.connect(charlieWallet).created(bobWallet.address, 10),
           ).to.be.fulfilled;
         });
       });
     });
   });
 
-  describe(".destroyed", () => {
-    describe("when not calling as a bound token", () => {
-      it("should revert", async () => {
+  describe('.destroyed', () => {
+    describe('when not calling as a bound token', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           suite: { compliance },
@@ -493,16 +493,16 @@ describe("ModularCompliance", () => {
         await expect(
           compliance
             .connect(anotherWallet)
-            .destroyed(ethers.constants.AddressZero, 0)
+            .destroyed(ethers.constants.AddressZero, 0),
         ).to.be.revertedWith(
-          "error : this address is not a token bound to the compliance contract"
+          'error : this address is not a token bound to the compliance contract',
         );
       });
     });
 
-    describe("when calling as a bound token", () => {
-      describe("when from address is null", () => {
-        it("should revert", async () => {
+    describe('when calling as a bound token', () => {
+      describe('when from address is null', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
             accounts: { charlieWallet },
@@ -511,42 +511,44 @@ describe("ModularCompliance", () => {
           await expect(
             compliance
               .connect(charlieWallet)
-              .destroyed(ethers.constants.AddressZero, 10)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .destroyed(ethers.constants.AddressZero, 10),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when amount is zero", () => {
-        it("should revert", async () => {
+      describe('when amount is zero', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance },
             accounts: { aliceWallet, charlieWallet },
           } = await loadFixture(deploySuiteWithModuleComplianceBoundToWallet);
 
           await expect(
-            compliance.connect(charlieWallet).destroyed(aliceWallet.address, 0)
-          ).to.be.revertedWith("invalid argument - no value burn");
+            compliance.connect(charlieWallet).destroyed(aliceWallet.address, 0),
+          ).to.be.revertedWith('invalid argument - no value burn');
         });
       });
 
-      describe("when amount is greater than zero", () => {
-        it("Should update the modules", async () => {
+      describe('when amount is greater than zero', () => {
+        it('Should update the modules', async () => {
           const {
             suite: { compliance },
             accounts: { aliceWallet, charlieWallet },
           } = await loadFixture(deploySuiteWithModuleComplianceBoundToWallet);
 
           await expect(
-            compliance.connect(charlieWallet).destroyed(aliceWallet.address, 10)
+            compliance
+              .connect(charlieWallet)
+              .destroyed(aliceWallet.address, 10),
           ).to.be.fulfilled;
         });
       });
     });
   });
 
-  describe(".callModuleFunction()", () => {
-    describe("when sender is not the owner", () => {
-      it("should revert", async () => {
+  describe('.callModuleFunction()', () => {
+    describe('when sender is not the owner', () => {
+      it('should revert', async () => {
         const {
           accounts: { anotherWallet },
           suite: { compliance },
@@ -557,14 +559,14 @@ describe("ModularCompliance", () => {
             .connect(anotherWallet)
             .callModuleFunction(
               ethers.utils.randomBytes(32),
-              ethers.constants.AddressZero
-            )
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+              ethers.constants.AddressZero,
+            ),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when module is not bound", () => {
-      it("should revert", async () => {
+    describe('when module is not bound', () => {
+      it('should revert', async () => {
         const {
           accounts: { deployer },
           suite: { compliance },
@@ -575,9 +577,9 @@ describe("ModularCompliance", () => {
             .connect(deployer)
             .callModuleFunction(
               ethers.utils.randomBytes(32),
-              ethers.constants.AddressZero
-            )
-        ).to.be.revertedWith("call only on bound module");
+              ethers.constants.AddressZero,
+            ),
+        ).to.be.revertedWith('call only on bound module');
       });
     });
   });

--- a/test/compliances/module-conditional-transfer.test.ts
+++ b/test/compliances/module-conditional-transfer.test.ts
@@ -1,19 +1,19 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { deployComplianceFixture } from "../fixtures/deploy-compliance.fixture";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { deployComplianceFixture } from '../fixtures/deploy-compliance.fixture';
 
-describe("ConditionalTransferModule", () => {
+describe('ConditionalTransferModule', () => {
   async function deployComplianceWithConditionalTransferModule() {
     const context = await loadFixture(deployComplianceFixture);
     const { compliance } = context.suite;
 
     const conditionalTransferModule = await ethers.deployContract(
-      "ConditionalTransferModule"
+      'ConditionalTransferModule',
     );
     await compliance.addModule(conditionalTransferModule.address);
 
-    const mockContract = await ethers.deployContract("MockContract");
+    const mockContract = await ethers.deployContract('MockContract');
 
     await compliance.bindToken(mockContract.address);
 
@@ -23,9 +23,9 @@ describe("ConditionalTransferModule", () => {
     };
   }
 
-  describe(".batchApproveTransfers", () => {
-    describe("when the sender is not the compliance", () => {
-      it("should revert", async () => {
+  describe('.batchApproveTransfers', () => {
+    describe('when the sender is not the compliance', () => {
+      it('should revert', async () => {
         const {
           suite: { conditionalTransferModule },
           accounts: { anotherWallet },
@@ -37,14 +37,14 @@ describe("ConditionalTransferModule", () => {
             .batchApproveTransfers(
               [anotherWallet.address],
               [anotherWallet.address],
-              [10]
-            )
-        ).to.be.revertedWith("only bound compliance can call");
+              [10],
+            ),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when the sender is the compliance", () => {
-      it("should approve the transfers", async () => {
+    describe('when the sender is the compliance', () => {
+      it('should approve the transfers', async () => {
         const {
           suite: { compliance, conditionalTransferModule, mockContract },
           accounts: { deployer, aliceWallet, bobWallet },
@@ -54,22 +54,22 @@ describe("ConditionalTransferModule", () => {
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchApproveTransfers(address[], address[], uint256[])",
-            ]).encodeFunctionData("batchApproveTransfers", [
+              'function batchApproveTransfers(address[], address[], uint256[])',
+            ]).encodeFunctionData('batchApproveTransfers', [
               [aliceWallet.address],
               [bobWallet.address],
               [10],
             ]),
-            conditionalTransferModule.address
+            conditionalTransferModule.address,
           );
 
         await expect(tx)
-          .to.emit(conditionalTransferModule, "TransferApproved")
+          .to.emit(conditionalTransferModule, 'TransferApproved')
           .withArgs(
             aliceWallet.address,
             bobWallet.address,
             10,
-            mockContract.address
+            mockContract.address,
           );
 
         expect(
@@ -79,9 +79,9 @@ describe("ConditionalTransferModule", () => {
               aliceWallet.address,
               bobWallet.address,
               10,
-              mockContract.address
-            )
-          )
+              mockContract.address,
+            ),
+          ),
         ).to.be.true;
 
         await expect(
@@ -91,17 +91,17 @@ describe("ConditionalTransferModule", () => {
               aliceWallet.address,
               bobWallet.address,
               10,
-              mockContract.address
-            )
-          )
+              mockContract.address,
+            ),
+          ),
         ).to.eventually.be.equal(1);
       });
     });
   });
 
-  describe(".batchUnApproveTransfers()", () => {
-    describe("when the sender is not the compliance", () => {
-      it("should revert", async () => {
+  describe('.batchUnApproveTransfers()', () => {
+    describe('when the sender is not the compliance', () => {
+      it('should revert', async () => {
         const {
           suite: { conditionalTransferModule },
           accounts: { anotherWallet },
@@ -113,15 +113,15 @@ describe("ConditionalTransferModule", () => {
             .batchUnApproveTransfers(
               [anotherWallet.address],
               [anotherWallet.address],
-              [10]
-            )
-        ).to.be.revertedWith("only bound compliance can call");
+              [10],
+            ),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when the sender is the compliance", () => {
-      describe("when the transfer is not approved", () => {
-        it("should revert", async () => {
+    describe('when the sender is the compliance', () => {
+      describe('when the transfer is not approved', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance, conditionalTransferModule },
             accounts: { deployer, aliceWallet, bobWallet },
@@ -132,19 +132,19 @@ describe("ConditionalTransferModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function batchUnApproveTransfers(address[], address[], uint256[])",
-                ]).encodeFunctionData("batchUnApproveTransfers", [
+                  'function batchUnApproveTransfers(address[], address[], uint256[])',
+                ]).encodeFunctionData('batchUnApproveTransfers', [
                   [aliceWallet.address],
                   [bobWallet.address],
                   [10],
                 ]),
-                conditionalTransferModule.address
-              )
-          ).to.be.revertedWith("not approved");
+                conditionalTransferModule.address,
+              ),
+          ).to.be.revertedWith('not approved');
         });
       });
 
-      it("should unapprove the transfers", async () => {
+      it('should unapprove the transfers', async () => {
         const {
           suite: { compliance, conditionalTransferModule, mockContract },
           accounts: { deployer, aliceWallet, bobWallet },
@@ -154,35 +154,35 @@ describe("ConditionalTransferModule", () => {
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchApproveTransfers(address[], address[], uint256[])",
-            ]).encodeFunctionData("batchApproveTransfers", [
+              'function batchApproveTransfers(address[], address[], uint256[])',
+            ]).encodeFunctionData('batchApproveTransfers', [
               [aliceWallet.address],
               [bobWallet.address],
               [10],
             ]),
-            conditionalTransferModule.address
+            conditionalTransferModule.address,
           );
 
         const tx = await compliance
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchUnApproveTransfers(address[], address[], uint256[])",
-            ]).encodeFunctionData("batchUnApproveTransfers", [
+              'function batchUnApproveTransfers(address[], address[], uint256[])',
+            ]).encodeFunctionData('batchUnApproveTransfers', [
               [aliceWallet.address],
               [bobWallet.address],
               [10],
             ]),
-            conditionalTransferModule.address
+            conditionalTransferModule.address,
           );
 
         await expect(tx)
-          .to.emit(conditionalTransferModule, "ApprovalRemoved")
+          .to.emit(conditionalTransferModule, 'ApprovalRemoved')
           .withArgs(
             aliceWallet.address,
             bobWallet.address,
             10,
-            mockContract.address
+            mockContract.address,
           );
 
         expect(
@@ -192,17 +192,17 @@ describe("ConditionalTransferModule", () => {
               aliceWallet.address,
               bobWallet.address,
               10,
-              mockContract.address
-            )
-          )
+              mockContract.address,
+            ),
+          ),
         ).to.be.false;
       });
     });
   });
 
-  describe(".approveTransfer()", () => {
-    describe("when the sender is not the compliance", () => {
-      it("should revert", async () => {
+  describe('.approveTransfer()', () => {
+    describe('when the sender is not the compliance', () => {
+      it('should revert', async () => {
         const {
           suite: { conditionalTransferModule },
           accounts: { anotherWallet },
@@ -211,15 +211,15 @@ describe("ConditionalTransferModule", () => {
         await expect(
           conditionalTransferModule
             .connect(anotherWallet)
-            .approveTransfer(anotherWallet.address, anotherWallet.address, 10)
-        ).to.be.revertedWith("only bound compliance can call");
+            .approveTransfer(anotherWallet.address, anotherWallet.address, 10),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
   });
 
-  describe(".unApproveTransfer()", () => {
-    describe("when the sender is not the compliance", () => {
-      it("should revert", async () => {
+  describe('.unApproveTransfer()', () => {
+    describe('when the sender is not the compliance', () => {
+      it('should revert', async () => {
         const {
           suite: { conditionalTransferModule },
           accounts: { anotherWallet },
@@ -228,15 +228,19 @@ describe("ConditionalTransferModule", () => {
         await expect(
           conditionalTransferModule
             .connect(anotherWallet)
-            .unApproveTransfer(anotherWallet.address, anotherWallet.address, 10)
-        ).to.be.revertedWith("only bound compliance can call");
+            .unApproveTransfer(
+              anotherWallet.address,
+              anotherWallet.address,
+              10,
+            ),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
   });
 
-  describe(".moduleCheck()", () => {
-    describe("when transfer is not approved", () => {
-      it("should return false", async () => {
+  describe('.moduleCheck()', () => {
+    describe('when transfer is not approved', () => {
+      it('should return false', async () => {
         const {
           suite: { compliance, conditionalTransferModule },
           accounts: { aliceWallet, bobWallet },
@@ -247,14 +251,14 @@ describe("ConditionalTransferModule", () => {
             aliceWallet.address,
             bobWallet.address,
             10,
-            compliance.address
-          )
+            compliance.address,
+          ),
         ).to.eventually.be.false;
       });
     });
 
-    describe("when transfer is approved", () => {
-      it("should return true", async () => {
+    describe('when transfer is approved', () => {
+      it('should return true', async () => {
         const {
           suite: { compliance, conditionalTransferModule },
           accounts: { deployer, aliceWallet, bobWallet },
@@ -264,13 +268,13 @@ describe("ConditionalTransferModule", () => {
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchApproveTransfers(address[], address[], uint256[])",
-            ]).encodeFunctionData("batchApproveTransfers", [
+              'function batchApproveTransfers(address[], address[], uint256[])',
+            ]).encodeFunctionData('batchApproveTransfers', [
               [aliceWallet.address],
               [bobWallet.address],
               [10],
             ]),
-            conditionalTransferModule.address
+            conditionalTransferModule.address,
           );
 
         await expect(
@@ -278,29 +282,29 @@ describe("ConditionalTransferModule", () => {
             aliceWallet.address,
             bobWallet.address,
             10,
-            compliance.address
-          )
+            compliance.address,
+          ),
         ).to.eventually.be.true;
       });
     });
   });
 
-  describe(".moduleBurnAction", () => {
-    describe("when called by a random wallet", () => {
-      it("should revert", async () => {
+  describe('.moduleBurnAction', () => {
+    describe('when called by a random wallet', () => {
+      it('should revert', async () => {
         const {
           suite: { conditionalTransferModule },
           accounts: { anotherWallet },
         } = await loadFixture(deployComplianceWithConditionalTransferModule);
 
         await expect(
-          conditionalTransferModule.moduleBurnAction(anotherWallet.address, 10)
-        ).to.be.revertedWith("only bound compliance can call");
+          conditionalTransferModule.moduleBurnAction(anotherWallet.address, 10),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when called by the compliance", () => {
-      it("should do nothing", async () => {
+    describe('when called by the compliance', () => {
+      it('should do nothing', async () => {
         const {
           suite: { conditionalTransferModule, compliance },
           accounts: { deployer, anotherWallet },
@@ -311,34 +315,34 @@ describe("ConditionalTransferModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function moduleBurnAction(address, uint256)",
-              ]).encodeFunctionData("moduleBurnAction", [
+                'function moduleBurnAction(address, uint256)',
+              ]).encodeFunctionData('moduleBurnAction', [
                 anotherWallet.address,
                 10,
               ]),
-              conditionalTransferModule.address
-            )
+              conditionalTransferModule.address,
+            ),
         ).to.eventually.be.fulfilled;
       });
     });
   });
 
-  describe(".moduleMintAction", () => {
-    describe("when called by a random wallet", () => {
-      it("should revert", async () => {
+  describe('.moduleMintAction', () => {
+    describe('when called by a random wallet', () => {
+      it('should revert', async () => {
         const {
           suite: { conditionalTransferModule },
           accounts: { anotherWallet },
         } = await loadFixture(deployComplianceWithConditionalTransferModule);
 
         await expect(
-          conditionalTransferModule.moduleMintAction(anotherWallet.address, 10)
-        ).to.be.revertedWith("only bound compliance can call");
+          conditionalTransferModule.moduleMintAction(anotherWallet.address, 10),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when called by the compliance", () => {
-      it("should do nothing", async () => {
+    describe('when called by the compliance', () => {
+      it('should do nothing', async () => {
         const {
           suite: { conditionalTransferModule, compliance },
           accounts: { deployer, anotherWallet },
@@ -349,21 +353,21 @@ describe("ConditionalTransferModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function moduleMintAction(address, uint256)",
-              ]).encodeFunctionData("moduleMintAction", [
+                'function moduleMintAction(address, uint256)',
+              ]).encodeFunctionData('moduleMintAction', [
                 anotherWallet.address,
                 10,
               ]),
-              conditionalTransferModule.address
-            )
+              conditionalTransferModule.address,
+            ),
         ).to.eventually.be.fulfilled;
       });
     });
   });
 
-  describe(".moduleTransferAction()", () => {
-    describe("when calling from a random wallet", () => {
-      it("should revert", async () => {
+  describe('.moduleTransferAction()', () => {
+    describe('when calling from a random wallet', () => {
+      it('should revert', async () => {
         const {
           suite: { conditionalTransferModule },
           accounts: { anotherWallet, aliceWallet, bobWallet },
@@ -372,14 +376,14 @@ describe("ConditionalTransferModule", () => {
         await expect(
           conditionalTransferModule
             .connect(anotherWallet)
-            .moduleTransferAction(aliceWallet.address, bobWallet.address, 10)
-        ).to.be.revertedWith("only bound compliance can call");
+            .moduleTransferAction(aliceWallet.address, bobWallet.address, 10),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling as the compliance", () => {
-      describe("when the transfer is not approved", () => {
-        it("should do nothing", async () => {
+    describe('when calling as the compliance', () => {
+      describe('when the transfer is not approved', () => {
+        it('should do nothing', async () => {
           const {
             suite: { compliance, conditionalTransferModule },
             accounts: { deployer, aliceWallet, bobWallet },
@@ -390,20 +394,20 @@ describe("ConditionalTransferModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function moduleTransferAction(address, address, uint256)",
-                ]).encodeFunctionData("moduleTransferAction", [
+                  'function moduleTransferAction(address, address, uint256)',
+                ]).encodeFunctionData('moduleTransferAction', [
                   aliceWallet.address,
                   bobWallet.address,
                   10,
                 ]),
-                conditionalTransferModule.address
-              )
+                conditionalTransferModule.address,
+              ),
           ).to.eventually.be.fulfilled;
         });
       });
 
-      describe("when the transfer is approved", () => {
-        it("should remove the transfer approval", async () => {
+      describe('when the transfer is approved', () => {
+        it('should remove the transfer approval', async () => {
           const {
             suite: { compliance, conditionalTransferModule, mockContract },
             accounts: { deployer, aliceWallet, bobWallet },
@@ -413,13 +417,13 @@ describe("ConditionalTransferModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function batchApproveTransfers(address[], address[], uint256[])",
-              ]).encodeFunctionData("batchApproveTransfers", [
+                'function batchApproveTransfers(address[], address[], uint256[])',
+              ]).encodeFunctionData('batchApproveTransfers', [
                 [aliceWallet.address],
                 [bobWallet.address],
                 [10],
               ]),
-              conditionalTransferModule.address
+              conditionalTransferModule.address,
             );
 
           const tx = await expect(
@@ -427,23 +431,23 @@ describe("ConditionalTransferModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function moduleTransferAction(address, address, uint256)",
-                ]).encodeFunctionData("moduleTransferAction", [
+                  'function moduleTransferAction(address, address, uint256)',
+                ]).encodeFunctionData('moduleTransferAction', [
                   aliceWallet.address,
                   bobWallet.address,
                   10,
                 ]),
-                conditionalTransferModule.address
-              )
+                conditionalTransferModule.address,
+              ),
           ).to.eventually.be.fulfilled;
 
           await expect(tx)
-            .to.emit(conditionalTransferModule, "ApprovalRemoved")
+            .to.emit(conditionalTransferModule, 'ApprovalRemoved')
             .withArgs(
               aliceWallet.address,
               bobWallet.address,
               10,
-              mockContract.address
+              mockContract.address,
             );
 
           expect(
@@ -453,9 +457,9 @@ describe("ConditionalTransferModule", () => {
                 aliceWallet.address,
                 bobWallet.address,
                 10,
-                mockContract.address
-              )
-            )
+                mockContract.address,
+              ),
+            ),
           ).to.be.false;
         });
       });

--- a/test/compliances/module-country-allow.test.ts
+++ b/test/compliances/module-country-allow.test.ts
@@ -1,24 +1,24 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { deployComplianceFixture } from "../fixtures/deploy-compliance.fixture";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { deployComplianceFixture } from '../fixtures/deploy-compliance.fixture';
 
-describe("CountryAllowModule", () => {
+describe('CountryAllowModule', () => {
   async function deployComplianceWithCountryAllowModule() {
     const context = await loadFixture(deployComplianceFixture);
     const { compliance } = context.suite;
 
     const countryAllowModule = await ethers.deployContract(
-      "CountryAllowModule"
+      'CountryAllowModule',
     );
     await compliance.addModule(countryAllowModule.address);
 
     return { ...context, suite: { ...context.suite, countryAllowModule } };
   }
 
-  describe(".batchAllowCountries()", () => {
-    describe("when calling not via the Compliance contract", () => {
-      it("should revert", async () => {
+  describe('.batchAllowCountries()', () => {
+    describe('when calling not via the Compliance contract', () => {
+      it('should revert', async () => {
         const {
           suite: { countryAllowModule },
           accounts: { anotherWallet },
@@ -27,26 +27,26 @@ describe("CountryAllowModule", () => {
         await expect(
           countryAllowModule
             .connect(anotherWallet)
-            .batchAllowCountries([42, 66])
-        ).to.be.revertedWith("only bound compliance can call");
+            .batchAllowCountries([42, 66]),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling as the owner", () => {
-      it("should revert", async () => {
+    describe('when calling as the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { countryAllowModule },
           accounts: { deployer },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
 
         await expect(
-          countryAllowModule.connect(deployer).batchAllowCountries([42, 66])
-        ).to.be.revertedWith("only bound compliance can call");
+          countryAllowModule.connect(deployer).batchAllowCountries([42, 66]),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling via the compliance contract", () => {
-      it("should allow the given countries", async () => {
+    describe('when calling via the compliance contract', () => {
+      it('should allow the given countries', async () => {
         const {
           suite: { compliance, countryAllowModule },
           accounts: { deployer },
@@ -56,31 +56,31 @@ describe("CountryAllowModule", () => {
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchAllowCountries(uint16[] calldata countries)",
-            ]).encodeFunctionData("batchAllowCountries", [[42, 66]]),
-            countryAllowModule.address
+              'function batchAllowCountries(uint16[] calldata countries)',
+            ]).encodeFunctionData('batchAllowCountries', [[42, 66]]),
+            countryAllowModule.address,
           );
 
         await expect(tx)
-          .to.emit(countryAllowModule, "CountryAllowed")
+          .to.emit(countryAllowModule, 'CountryAllowed')
           .withArgs(compliance.address, 42);
         await expect(tx)
-          .to.emit(countryAllowModule, "CountryAllowed")
+          .to.emit(countryAllowModule, 'CountryAllowed')
           .withArgs(compliance.address, 66);
 
         expect(
-          await countryAllowModule.isCountryAllowed(compliance.address, 42)
+          await countryAllowModule.isCountryAllowed(compliance.address, 42),
         ).to.be.true;
         expect(
-          await countryAllowModule.isCountryAllowed(compliance.address, 66)
+          await countryAllowModule.isCountryAllowed(compliance.address, 66),
         ).to.be.true;
       });
     });
   });
 
-  describe(".batchDisallowCountries()", () => {
-    describe("when calling not via the Compliance contract", () => {
-      it("should revert", async () => {
+  describe('.batchDisallowCountries()', () => {
+    describe('when calling not via the Compliance contract', () => {
+      it('should revert', async () => {
         const {
           suite: { countryAllowModule },
           accounts: { anotherWallet },
@@ -89,26 +89,26 @@ describe("CountryAllowModule", () => {
         await expect(
           countryAllowModule
             .connect(anotherWallet)
-            .batchDisallowCountries([42, 66])
-        ).to.be.revertedWith("only bound compliance can call");
+            .batchDisallowCountries([42, 66]),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling as the owner", () => {
-      it("should revert", async () => {
+    describe('when calling as the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { countryAllowModule },
           accounts: { deployer },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
 
         await expect(
-          countryAllowModule.connect(deployer).batchDisallowCountries([42, 66])
-        ).to.be.revertedWith("only bound compliance can call");
+          countryAllowModule.connect(deployer).batchDisallowCountries([42, 66]),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling via the compliance contract", () => {
-      it("should disallow the given countries", async () => {
+    describe('when calling via the compliance contract', () => {
+      it('should disallow the given countries', async () => {
         const {
           suite: { compliance, countryAllowModule },
           accounts: { deployer },
@@ -118,58 +118,58 @@ describe("CountryAllowModule", () => {
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchDisallowCountries(uint16[] calldata countries)",
-            ]).encodeFunctionData("batchDisallowCountries", [[42, 66]]),
-            countryAllowModule.address
+              'function batchDisallowCountries(uint16[] calldata countries)',
+            ]).encodeFunctionData('batchDisallowCountries', [[42, 66]]),
+            countryAllowModule.address,
           );
 
         await expect(tx)
-          .to.emit(countryAllowModule, "CountryUnallowed")
+          .to.emit(countryAllowModule, 'CountryUnallowed')
           .withArgs(compliance.address, 42);
         await expect(tx)
-          .to.emit(countryAllowModule, "CountryUnallowed")
+          .to.emit(countryAllowModule, 'CountryUnallowed')
           .withArgs(compliance.address, 66);
 
         expect(
-          await countryAllowModule.isCountryAllowed(compliance.address, 42)
+          await countryAllowModule.isCountryAllowed(compliance.address, 42),
         ).to.be.false;
         expect(
-          await countryAllowModule.isCountryAllowed(compliance.address, 66)
+          await countryAllowModule.isCountryAllowed(compliance.address, 66),
         ).to.be.false;
       });
     });
   });
 
-  describe(".addAllowedCountry()", () => {
-    describe("when calling not via the Compliance contract", () => {
-      it("should revert", async () => {
+  describe('.addAllowedCountry()', () => {
+    describe('when calling not via the Compliance contract', () => {
+      it('should revert', async () => {
         const {
           suite: { countryAllowModule },
           accounts: { anotherWallet },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
 
         await expect(
-          countryAllowModule.connect(anotherWallet).addAllowedCountry(42)
-        ).to.be.revertedWith("only bound compliance can call");
+          countryAllowModule.connect(anotherWallet).addAllowedCountry(42),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling as the owner", () => {
-      it("should revert", async () => {
+    describe('when calling as the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { countryAllowModule },
           accounts: { deployer },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
 
         await expect(
-          countryAllowModule.connect(deployer).addAllowedCountry(42)
-        ).to.be.revertedWith("only bound compliance can call");
+          countryAllowModule.connect(deployer).addAllowedCountry(42),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling via the compliance contract", () => {
-      describe("when country is already allowed", () => {
-        it("should revert", async () => {
+    describe('when calling via the compliance contract', () => {
+      describe('when country is already allowed', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance, countryAllowModule },
             accounts: { deployer },
@@ -179,9 +179,9 @@ describe("CountryAllowModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function addAllowedCountry(uint16 country)",
-              ]).encodeFunctionData("addAllowedCountry", [42]),
-              countryAllowModule.address
+                'function addAllowedCountry(uint16 country)',
+              ]).encodeFunctionData('addAllowedCountry', [42]),
+              countryAllowModule.address,
             );
 
           await expect(
@@ -189,21 +189,21 @@ describe("CountryAllowModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function addAllowedCountry(uint16 country)",
-                ]).encodeFunctionData("addAllowedCountry", [42]),
-                countryAllowModule.address
-              )
+                  'function addAllowedCountry(uint16 country)',
+                ]).encodeFunctionData('addAllowedCountry', [42]),
+                countryAllowModule.address,
+              ),
           )
             .to.be.revertedWithCustomError(
               countryAllowModule,
-              "CountryAlreadyAllowed"
+              'CountryAlreadyAllowed',
             )
             .withArgs(compliance.address, 42);
         });
       });
 
-      describe("when country is not allowed", () => {
-        it("should allow the given country", async () => {
+      describe('when country is not allowed', () => {
+        it('should allow the given country', async () => {
           const {
             suite: { compliance, countryAllowModule },
             accounts: { deployer },
@@ -213,53 +213,53 @@ describe("CountryAllowModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function addAllowedCountry(uint16 country)",
-              ]).encodeFunctionData("addAllowedCountry", [42]),
-              countryAllowModule.address
+                'function addAllowedCountry(uint16 country)',
+              ]).encodeFunctionData('addAllowedCountry', [42]),
+              countryAllowModule.address,
             );
 
           await expect(tx)
-            .to.emit(countryAllowModule, "CountryAllowed")
+            .to.emit(countryAllowModule, 'CountryAllowed')
             .withArgs(compliance.address, 42);
 
           expect(
-            await countryAllowModule.isCountryAllowed(compliance.address, 42)
+            await countryAllowModule.isCountryAllowed(compliance.address, 42),
           ).to.be.true;
         });
       });
     });
   });
 
-  describe(".removeAllowedCountry()", () => {
-    describe("when calling not via the Compliance contract", () => {
-      it("should revert", async () => {
+  describe('.removeAllowedCountry()', () => {
+    describe('when calling not via the Compliance contract', () => {
+      it('should revert', async () => {
         const {
           suite: { countryAllowModule },
           accounts: { anotherWallet },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
 
         await expect(
-          countryAllowModule.connect(anotherWallet).removeAllowedCountry(42)
-        ).to.be.revertedWith("only bound compliance can call");
+          countryAllowModule.connect(anotherWallet).removeAllowedCountry(42),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling as the owner", () => {
-      it("should revert", async () => {
+    describe('when calling as the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { countryAllowModule },
           accounts: { deployer },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
 
         await expect(
-          countryAllowModule.connect(deployer).removeAllowedCountry(42)
-        ).to.be.revertedWith("only bound compliance can call");
+          countryAllowModule.connect(deployer).removeAllowedCountry(42),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling via the compliance contract", () => {
-      describe("when country is not allowed", () => {
-        it("should revert", async () => {
+    describe('when calling via the compliance contract', () => {
+      describe('when country is not allowed', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance, countryAllowModule },
             accounts: { deployer },
@@ -270,21 +270,21 @@ describe("CountryAllowModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function removeAllowedCountry(uint16 country)",
-                ]).encodeFunctionData("removeAllowedCountry", [42]),
-                countryAllowModule.address
-              )
+                  'function removeAllowedCountry(uint16 country)',
+                ]).encodeFunctionData('removeAllowedCountry', [42]),
+                countryAllowModule.address,
+              ),
           )
             .to.be.revertedWithCustomError(
               countryAllowModule,
-              "CountryNotAllowed"
+              'CountryNotAllowed',
             )
             .withArgs(compliance.address, 42);
         });
       });
 
-      describe("when country is allowed", () => {
-        it("should disallow the given country", async () => {
+      describe('when country is allowed', () => {
+        it('should disallow the given country', async () => {
           const {
             suite: { compliance, countryAllowModule },
             accounts: { deployer },
@@ -294,49 +294,49 @@ describe("CountryAllowModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function addAllowedCountry(uint16 country)",
-              ]).encodeFunctionData("addAllowedCountry", [42]),
-              countryAllowModule.address
+                'function addAllowedCountry(uint16 country)',
+              ]).encodeFunctionData('addAllowedCountry', [42]),
+              countryAllowModule.address,
             );
 
           const tx = await compliance
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function removeAllowedCountry(uint16 country)",
-              ]).encodeFunctionData("removeAllowedCountry", [42]),
-              countryAllowModule.address
+                'function removeAllowedCountry(uint16 country)',
+              ]).encodeFunctionData('removeAllowedCountry', [42]),
+              countryAllowModule.address,
             );
 
           await expect(tx)
-            .to.emit(countryAllowModule, "CountryUnallowed")
+            .to.emit(countryAllowModule, 'CountryUnallowed')
             .withArgs(compliance.address, 42);
 
           expect(
-            await countryAllowModule.isCountryAllowed(compliance.address, 42)
+            await countryAllowModule.isCountryAllowed(compliance.address, 42),
           ).to.be.false;
         });
       });
     });
   });
 
-  describe(".moduleCheck", () => {
-    describe("when identity country is allowed", () => {
-      it("should return true", async () => {
+  describe('.moduleCheck', () => {
+    describe('when identity country is allowed', () => {
+      it('should return true', async () => {
         const {
           suite: { compliance, countryAllowModule },
           accounts: { deployer, aliceWallet, bobWallet },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
-        const contract = await ethers.deployContract("MockContract");
+        const contract = await ethers.deployContract('MockContract');
         await compliance.bindToken(contract.address);
 
         await compliance
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchAllowCountries(uint16[] calldata countries)",
-            ]).encodeFunctionData("batchAllowCountries", [[42, 66]]),
-            countryAllowModule.address
+              'function batchAllowCountries(uint16[] calldata countries)',
+            ]).encodeFunctionData('batchAllowCountries', [[42, 66]]),
+            countryAllowModule.address,
           );
 
         await contract.setInvestorCountry(42);
@@ -346,31 +346,31 @@ describe("CountryAllowModule", () => {
             aliceWallet.address,
             bobWallet.address,
             10,
-            compliance.address
-          )
+            compliance.address,
+          ),
         ).to.be.eventually.true;
         await expect(
-          compliance.canTransfer(aliceWallet.address, bobWallet.address, 10)
+          compliance.canTransfer(aliceWallet.address, bobWallet.address, 10),
         ).to.be.eventually.true;
       });
     });
 
-    describe("when identity country is not allowed", () => {
-      it("should return false", async () => {
+    describe('when identity country is not allowed', () => {
+      it('should return false', async () => {
         const {
           suite: { compliance, countryAllowModule },
           accounts: { deployer, aliceWallet, bobWallet },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
-        const contract = await ethers.deployContract("MockContract");
+        const contract = await ethers.deployContract('MockContract');
         await compliance.bindToken(contract.address);
 
         await compliance
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchAllowCountries(uint16[] calldata countries)",
-            ]).encodeFunctionData("batchAllowCountries", [[42, 66]]),
-            countryAllowModule.address
+              'function batchAllowCountries(uint16[] calldata countries)',
+            ]).encodeFunctionData('batchAllowCountries', [[42, 66]]),
+            countryAllowModule.address,
           );
 
         await contract.setInvestorCountry(10);
@@ -380,19 +380,19 @@ describe("CountryAllowModule", () => {
             aliceWallet.address,
             bobWallet.address,
             16,
-            compliance.address
-          )
+            compliance.address,
+          ),
         ).to.be.eventually.false;
         await expect(
-          compliance.canTransfer(aliceWallet.address, bobWallet.address, 16)
+          compliance.canTransfer(aliceWallet.address, bobWallet.address, 16),
         ).to.be.eventually.false;
       });
     });
   });
 
-  describe(".isComplianceBound()", () => {
-    describe("when the address is a bound compliance", () => {
-      it("should return true", async () => {
+  describe('.isComplianceBound()', () => {
+    describe('when the address is a bound compliance', () => {
+      it('should return true', async () => {
         const {
           suite: { countryAllowModule, compliance },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
@@ -402,22 +402,22 @@ describe("CountryAllowModule", () => {
       });
     });
 
-    describe("when the address is not a bound compliance", () => {
-      it("should return false", async () => {
+    describe('when the address is not a bound compliance', () => {
+      it('should return false', async () => {
         const {
           suite: { countryAllowModule },
         } = await loadFixture(deployComplianceWithCountryAllowModule);
 
         await expect(
-          countryAllowModule.isComplianceBound(countryAllowModule.address)
+          countryAllowModule.isComplianceBound(countryAllowModule.address),
         ).to.be.eventually.false;
       });
     });
   });
 
-  describe(".unbindCompliance()", () => {
-    describe("when sender is not a bound compliance", () => {
-      it("should revert", async () => {
+  describe('.unbindCompliance()', () => {
+    describe('when sender is not a bound compliance', () => {
+      it('should revert', async () => {
         const {
           suite: { countryAllowModule, compliance },
           accounts: { anotherWallet },
@@ -426,8 +426,8 @@ describe("CountryAllowModule", () => {
         await expect(
           countryAllowModule
             .connect(anotherWallet)
-            .unbindCompliance(compliance.address)
-        ).to.be.revertedWith("only bound compliance can call");
+            .unbindCompliance(compliance.address),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
   });

--- a/test/compliances/module-country-restrict.test.ts
+++ b/test/compliances/module-country-restrict.test.ts
@@ -1,51 +1,53 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { deployComplianceFixture } from "../fixtures/deploy-compliance.fixture";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { deployComplianceFixture } from '../fixtures/deploy-compliance.fixture';
 
-describe("CountryRestrictModule", () => {
+describe('CountryRestrictModule', () => {
   async function deployComplianceWithCountryRestrictModule() {
     const context = await loadFixture(deployComplianceFixture);
     const { compliance } = context.suite;
 
     const countryRestrictModule = await ethers.deployContract(
-      "CountryRestrictModule"
+      'CountryRestrictModule',
     );
     await compliance.addModule(countryRestrictModule.address);
 
     return { ...context, suite: { ...context.suite, countryRestrictModule } };
   }
 
-  describe(".addCountryRestriction()", () => {
-    describe("when the sender is a random wallet", () => {
-      it("should reverts", async () => {
+  describe('.addCountryRestriction()', () => {
+    describe('when the sender is a random wallet', () => {
+      it('should reverts', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { anotherWallet },
         } = await loadFixture(deployComplianceWithCountryRestrictModule);
 
         await expect(
-          countryRestrictModule.connect(anotherWallet).addCountryRestriction(42)
-        ).to.be.revertedWith("only bound compliance can call");
+          countryRestrictModule
+            .connect(anotherWallet)
+            .addCountryRestriction(42),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when the sender is the deployer", () => {
-      it("should revert", async () => {
+    describe('when the sender is the deployer', () => {
+      it('should revert', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { deployer },
         } = await loadFixture(deployComplianceWithCountryRestrictModule);
 
         await expect(
-          countryRestrictModule.connect(deployer).addCountryRestriction(42)
-        ).to.be.revertedWith("only bound compliance can call");
+          countryRestrictModule.connect(deployer).addCountryRestriction(42),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when called via the compliance", () => {
-      describe("when country is already restricted", () => {
-        it("should revert", async () => {
+    describe('when called via the compliance', () => {
+      describe('when country is already restricted', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance, countryRestrictModule },
             accounts: { deployer },
@@ -55,9 +57,9 @@ describe("CountryRestrictModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function addCountryRestriction(uint16 country)",
-              ]).encodeFunctionData("addCountryRestriction", [42]),
-              countryRestrictModule.address
+                'function addCountryRestriction(uint16 country)',
+              ]).encodeFunctionData('addCountryRestriction', [42]),
+              countryRestrictModule.address,
             );
 
           await expect(
@@ -65,16 +67,16 @@ describe("CountryRestrictModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function addCountryRestriction(uint16 country)",
-                ]).encodeFunctionData("addCountryRestriction", [42]),
-                countryRestrictModule.address
-              )
-          ).to.be.revertedWith("country already restricted");
+                  'function addCountryRestriction(uint16 country)',
+                ]).encodeFunctionData('addCountryRestriction', [42]),
+                countryRestrictModule.address,
+              ),
+          ).to.be.revertedWith('country already restricted');
         });
       });
 
-      describe("when country is not restricted", () => {
-        it("should add the country restriction", async () => {
+      describe('when country is not restricted', () => {
+        it('should add the country restriction', async () => {
           const {
             suite: { compliance, countryRestrictModule },
             accounts: { deployer },
@@ -84,29 +86,29 @@ describe("CountryRestrictModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function addCountryRestriction(uint16 country)",
-              ]).encodeFunctionData("addCountryRestriction", [42]),
-              countryRestrictModule.address
+                'function addCountryRestriction(uint16 country)',
+              ]).encodeFunctionData('addCountryRestriction', [42]),
+              countryRestrictModule.address,
             );
 
           await expect(tx)
-            .to.emit(countryRestrictModule, "AddedRestrictedCountry")
+            .to.emit(countryRestrictModule, 'AddedRestrictedCountry')
             .withArgs(compliance.address, 42);
 
           expect(
             await countryRestrictModule.isCountryRestricted(
               compliance.address,
-              42
-            )
+              42,
+            ),
           ).to.be.true;
         });
       });
     });
   });
 
-  describe(".removeCountryRestriction()", () => {
-    describe("when the sender is a random wallet", () => {
-      it("should reverts", async () => {
+  describe('.removeCountryRestriction()', () => {
+    describe('when the sender is a random wallet', () => {
+      it('should reverts', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { anotherWallet },
@@ -115,27 +117,27 @@ describe("CountryRestrictModule", () => {
         await expect(
           countryRestrictModule
             .connect(anotherWallet)
-            .removeCountryRestriction(42)
-        ).to.be.revertedWith("only bound compliance can call");
+            .removeCountryRestriction(42),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when the sender is the deployer", () => {
-      it("should revert", async () => {
+    describe('when the sender is the deployer', () => {
+      it('should revert', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { deployer },
         } = await loadFixture(deployComplianceWithCountryRestrictModule);
 
         await expect(
-          countryRestrictModule.connect(deployer).removeCountryRestriction(42)
-        ).to.be.revertedWith("only bound compliance can call");
+          countryRestrictModule.connect(deployer).removeCountryRestriction(42),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when called via the compliance", () => {
-      describe("when country is not restricted", () => {
-        it("should revert", async () => {
+    describe('when called via the compliance', () => {
+      describe('when country is not restricted', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance, countryRestrictModule },
             accounts: { deployer },
@@ -146,16 +148,16 @@ describe("CountryRestrictModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function removeCountryRestriction(uint16 country)",
-                ]).encodeFunctionData("removeCountryRestriction", [42]),
-                countryRestrictModule.address
-              )
-          ).to.be.revertedWith("country not restricted");
+                  'function removeCountryRestriction(uint16 country)',
+                ]).encodeFunctionData('removeCountryRestriction', [42]),
+                countryRestrictModule.address,
+              ),
+          ).to.be.revertedWith('country not restricted');
         });
       });
 
-      describe("when country is restricted", () => {
-        it("should remove the country restriction", async () => {
+      describe('when country is restricted', () => {
+        it('should remove the country restriction', async () => {
           const {
             suite: { compliance, countryRestrictModule },
             accounts: { deployer },
@@ -165,38 +167,38 @@ describe("CountryRestrictModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function addCountryRestriction(uint16 country)",
-              ]).encodeFunctionData("addCountryRestriction", [42]),
-              countryRestrictModule.address
+                'function addCountryRestriction(uint16 country)',
+              ]).encodeFunctionData('addCountryRestriction', [42]),
+              countryRestrictModule.address,
             );
 
           const tx = await compliance
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function removeCountryRestriction(uint16 country)",
-              ]).encodeFunctionData("removeCountryRestriction", [42]),
-              countryRestrictModule.address
+                'function removeCountryRestriction(uint16 country)',
+              ]).encodeFunctionData('removeCountryRestriction', [42]),
+              countryRestrictModule.address,
             );
 
           await expect(tx)
-            .to.emit(countryRestrictModule, "RemovedRestrictedCountry")
+            .to.emit(countryRestrictModule, 'RemovedRestrictedCountry')
             .withArgs(compliance.address, 42);
 
           expect(
             await countryRestrictModule.isCountryRestricted(
               compliance.address,
-              42
-            )
+              42,
+            ),
           ).to.be.false;
         });
       });
     });
   });
 
-  describe(".batchRestrictCountries()", () => {
-    describe("when the sender is a random wallet", () => {
-      it("should reverts", async () => {
+  describe('.batchRestrictCountries()', () => {
+    describe('when the sender is a random wallet', () => {
+      it('should reverts', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { anotherWallet },
@@ -205,27 +207,27 @@ describe("CountryRestrictModule", () => {
         await expect(
           countryRestrictModule
             .connect(anotherWallet)
-            .batchRestrictCountries([42])
-        ).to.be.revertedWith("only bound compliance can call");
+            .batchRestrictCountries([42]),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when the sender is the deployer", () => {
-      it("should revert", async () => {
+    describe('when the sender is the deployer', () => {
+      it('should revert', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { deployer },
         } = await loadFixture(deployComplianceWithCountryRestrictModule);
 
         await expect(
-          countryRestrictModule.connect(deployer).batchRestrictCountries([42])
-        ).to.be.revertedWith("only bound compliance can call");
+          countryRestrictModule.connect(deployer).batchRestrictCountries([42]),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when called via the compliance", () => {
-      describe("when attemptint to restrict more than 195 countries at once", () => {
-        it("should revert", async () => {
+    describe('when called via the compliance', () => {
+      describe('when attemptint to restrict more than 195 countries at once', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance, countryRestrictModule },
             accounts: { deployer },
@@ -236,18 +238,18 @@ describe("CountryRestrictModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function batchRestrictCountries(uint16[] memory countries)",
-                ]).encodeFunctionData("batchRestrictCountries", [
+                  'function batchRestrictCountries(uint16[] memory countries)',
+                ]).encodeFunctionData('batchRestrictCountries', [
                   Array.from({ length: 195 }, (_, i) => i),
                 ]),
-                countryRestrictModule.address
-              )
-          ).to.be.revertedWith("maximum 195 can be restricted in one batch");
+                countryRestrictModule.address,
+              ),
+          ).to.be.revertedWith('maximum 195 can be restricted in one batch');
         });
       });
 
-      describe("when a country is already restricted", () => {
-        it("should revert", async () => {
+      describe('when a country is already restricted', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance, countryRestrictModule },
             accounts: { deployer },
@@ -257,9 +259,9 @@ describe("CountryRestrictModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function addCountryRestriction(uint16 country)",
-              ]).encodeFunctionData("addCountryRestriction", [42]),
-              countryRestrictModule.address
+                'function addCountryRestriction(uint16 country)',
+              ]).encodeFunctionData('addCountryRestriction', [42]),
+              countryRestrictModule.address,
             );
 
           await expect(
@@ -267,15 +269,15 @@ describe("CountryRestrictModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function batchRestrictCountries(uint16[] memory countries)",
-                ]).encodeFunctionData("batchRestrictCountries", [[12, 42, 67]]),
-                countryRestrictModule.address
-              )
-          ).to.be.revertedWith("country already restricted");
+                  'function batchRestrictCountries(uint16[] memory countries)',
+                ]).encodeFunctionData('batchRestrictCountries', [[12, 42, 67]]),
+                countryRestrictModule.address,
+              ),
+          ).to.be.revertedWith('country already restricted');
         });
       });
 
-      it("should add the country restriction", async () => {
+      it('should add the country restriction', async () => {
         const {
           suite: { compliance, countryRestrictModule },
           accounts: { deployer },
@@ -285,37 +287,37 @@ describe("CountryRestrictModule", () => {
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchRestrictCountries(uint16[] memory countries)",
-            ]).encodeFunctionData("batchRestrictCountries", [[42, 66]]),
-            countryRestrictModule.address
+              'function batchRestrictCountries(uint16[] memory countries)',
+            ]).encodeFunctionData('batchRestrictCountries', [[42, 66]]),
+            countryRestrictModule.address,
           );
 
         await expect(tx)
-          .to.emit(countryRestrictModule, "AddedRestrictedCountry")
+          .to.emit(countryRestrictModule, 'AddedRestrictedCountry')
           .withArgs(compliance.address, 42);
         await expect(tx)
-          .to.emit(countryRestrictModule, "AddedRestrictedCountry")
+          .to.emit(countryRestrictModule, 'AddedRestrictedCountry')
           .withArgs(compliance.address, 66);
 
         expect(
           await countryRestrictModule.isCountryRestricted(
             compliance.address,
-            42
-          )
+            42,
+          ),
         ).to.be.true;
         expect(
           await countryRestrictModule.isCountryRestricted(
             compliance.address,
-            66
-          )
+            66,
+          ),
         ).to.be.true;
       });
     });
   });
 
-  describe(".batchUnrestrictCountries()", () => {
-    describe("when the sender is a random wallet", () => {
-      it("should reverts", async () => {
+  describe('.batchUnrestrictCountries()', () => {
+    describe('when the sender is a random wallet', () => {
+      it('should reverts', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { anotherWallet },
@@ -324,27 +326,29 @@ describe("CountryRestrictModule", () => {
         await expect(
           countryRestrictModule
             .connect(anotherWallet)
-            .batchUnrestrictCountries([42])
-        ).to.be.revertedWith("only bound compliance can call");
+            .batchUnrestrictCountries([42]),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when the sender is the deployer", () => {
-      it("should revert", async () => {
+    describe('when the sender is the deployer', () => {
+      it('should revert', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { deployer },
         } = await loadFixture(deployComplianceWithCountryRestrictModule);
 
         await expect(
-          countryRestrictModule.connect(deployer).batchUnrestrictCountries([42])
-        ).to.be.revertedWith("only bound compliance can call");
+          countryRestrictModule
+            .connect(deployer)
+            .batchUnrestrictCountries([42]),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when called via the compliance", () => {
-      describe("when attempting to unrestrict more than 195 countries at once", () => {
-        it("should revert", async () => {
+    describe('when called via the compliance', () => {
+      describe('when attempting to unrestrict more than 195 countries at once', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance, countryRestrictModule },
             accounts: { deployer },
@@ -355,18 +359,18 @@ describe("CountryRestrictModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function batchUnrestrictCountries(uint16[] memory countries)",
-                ]).encodeFunctionData("batchUnrestrictCountries", [
+                  'function batchUnrestrictCountries(uint16[] memory countries)',
+                ]).encodeFunctionData('batchUnrestrictCountries', [
                   Array.from({ length: 195 }, (_, i) => i),
                 ]),
-                countryRestrictModule.address
-              )
-          ).to.be.revertedWith("maximum 195 can be unrestricted in one batch");
+                countryRestrictModule.address,
+              ),
+          ).to.be.revertedWith('maximum 195 can be unrestricted in one batch');
         });
       });
 
-      describe("when a country is not restricted", () => {
-        it("should revert", async () => {
+      describe('when a country is not restricted', () => {
+        it('should revert', async () => {
           const {
             suite: { compliance, countryRestrictModule },
             accounts: { deployer },
@@ -377,17 +381,17 @@ describe("CountryRestrictModule", () => {
               .connect(deployer)
               .callModuleFunction(
                 new ethers.utils.Interface([
-                  "function batchUnrestrictCountries(uint16[] memory countries)",
-                ]).encodeFunctionData("batchUnrestrictCountries", [
+                  'function batchUnrestrictCountries(uint16[] memory countries)',
+                ]).encodeFunctionData('batchUnrestrictCountries', [
                   [12, 42, 67],
                 ]),
-                countryRestrictModule.address
-              )
-          ).to.be.revertedWith("country not restricted");
+                countryRestrictModule.address,
+              ),
+          ).to.be.revertedWith('country not restricted');
         });
       });
 
-      it("should remove the country restriction", async () => {
+      it('should remove the country restriction', async () => {
         const {
           suite: { compliance, countryRestrictModule },
           accounts: { deployer },
@@ -397,46 +401,46 @@ describe("CountryRestrictModule", () => {
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchRestrictCountries(uint16[] memory countries)",
-            ]).encodeFunctionData("batchRestrictCountries", [[42, 66]]),
-            countryRestrictModule.address
+              'function batchRestrictCountries(uint16[] memory countries)',
+            ]).encodeFunctionData('batchRestrictCountries', [[42, 66]]),
+            countryRestrictModule.address,
           );
 
         const tx = await compliance
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchUnrestrictCountries(uint16[] memory countries)",
-            ]).encodeFunctionData("batchUnrestrictCountries", [[42, 66]]),
-            countryRestrictModule.address
+              'function batchUnrestrictCountries(uint16[] memory countries)',
+            ]).encodeFunctionData('batchUnrestrictCountries', [[42, 66]]),
+            countryRestrictModule.address,
           );
 
         await expect(tx)
-          .to.emit(countryRestrictModule, "RemovedRestrictedCountry")
+          .to.emit(countryRestrictModule, 'RemovedRestrictedCountry')
           .withArgs(compliance.address, 42);
         await expect(tx)
-          .to.emit(countryRestrictModule, "RemovedRestrictedCountry")
+          .to.emit(countryRestrictModule, 'RemovedRestrictedCountry')
           .withArgs(compliance.address, 66);
 
         expect(
           await countryRestrictModule.isCountryRestricted(
             compliance.address,
-            42
-          )
+            42,
+          ),
         ).to.be.false;
         expect(
           await countryRestrictModule.isCountryRestricted(
             compliance.address,
-            66
-          )
+            66,
+          ),
         ).to.be.false;
       });
     });
   });
 
-  describe(".moduleTransferAction()", () => {
-    describe("when calling from a random wallet", () => {
-      it("should revert", async () => {
+  describe('.moduleTransferAction()', () => {
+    describe('when calling from a random wallet', () => {
+      it('should revert', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { anotherWallet, aliceWallet, bobWallet },
@@ -445,13 +449,13 @@ describe("CountryRestrictModule", () => {
         await expect(
           countryRestrictModule
             .connect(anotherWallet)
-            .moduleTransferAction(aliceWallet.address, bobWallet.address, 10)
-        ).to.be.revertedWith("only bound compliance can call");
+            .moduleTransferAction(aliceWallet.address, bobWallet.address, 10),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling as the compliance", () => {
-      it("should do nothing", async () => {
+    describe('when calling as the compliance', () => {
+      it('should do nothing', async () => {
         const {
           suite: { compliance, countryRestrictModule },
           accounts: { deployer, aliceWallet, bobWallet },
@@ -462,22 +466,22 @@ describe("CountryRestrictModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function moduleTransferAction(address, address, uint256)",
-              ]).encodeFunctionData("moduleTransferAction", [
+                'function moduleTransferAction(address, address, uint256)',
+              ]).encodeFunctionData('moduleTransferAction', [
                 aliceWallet.address,
                 bobWallet.address,
                 10,
               ]),
-              countryRestrictModule.address
-            )
+              countryRestrictModule.address,
+            ),
         ).to.eventually.be.fulfilled;
       });
     });
   });
 
-  describe(".moduleMintAction()", () => {
-    describe("when calling from a random wallet", () => {
-      it("should revert", async () => {
+  describe('.moduleMintAction()', () => {
+    describe('when calling from a random wallet', () => {
+      it('should revert', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { anotherWallet },
@@ -486,13 +490,13 @@ describe("CountryRestrictModule", () => {
         await expect(
           countryRestrictModule
             .connect(anotherWallet)
-            .moduleMintAction(anotherWallet.address, 10)
-        ).to.be.revertedWith("only bound compliance can call");
+            .moduleMintAction(anotherWallet.address, 10),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling as the compliance", () => {
-      it("should do nothing", async () => {
+    describe('when calling as the compliance', () => {
+      it('should do nothing', async () => {
         const {
           suite: { compliance, countryRestrictModule },
           accounts: { deployer, anotherWallet },
@@ -503,21 +507,21 @@ describe("CountryRestrictModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function moduleMintAction(address, uint256)",
-              ]).encodeFunctionData("moduleMintAction", [
+                'function moduleMintAction(address, uint256)',
+              ]).encodeFunctionData('moduleMintAction', [
                 anotherWallet.address,
                 10,
               ]),
-              countryRestrictModule.address
-            )
+              countryRestrictModule.address,
+            ),
         ).to.eventually.be.fulfilled;
       });
     });
   });
 
-  describe(".moduleBurnAction()", () => {
-    describe("when calling from a random wallet", () => {
-      it("should revert", async () => {
+  describe('.moduleBurnAction()', () => {
+    describe('when calling from a random wallet', () => {
+      it('should revert', async () => {
         const {
           suite: { countryRestrictModule },
           accounts: { anotherWallet },
@@ -526,13 +530,13 @@ describe("CountryRestrictModule", () => {
         await expect(
           countryRestrictModule
             .connect(anotherWallet)
-            .moduleBurnAction(anotherWallet.address, 10)
-        ).to.be.revertedWith("only bound compliance can call");
+            .moduleBurnAction(anotherWallet.address, 10),
+        ).to.be.revertedWith('only bound compliance can call');
       });
     });
 
-    describe("when calling as the compliance", () => {
-      it("should do nothing", async () => {
+    describe('when calling as the compliance', () => {
+      it('should do nothing', async () => {
         const {
           suite: { compliance, countryRestrictModule },
           accounts: { deployer, anotherWallet },
@@ -543,35 +547,35 @@ describe("CountryRestrictModule", () => {
             .connect(deployer)
             .callModuleFunction(
               new ethers.utils.Interface([
-                "function moduleBurnAction(address, uint256)",
-              ]).encodeFunctionData("moduleBurnAction", [
+                'function moduleBurnAction(address, uint256)',
+              ]).encodeFunctionData('moduleBurnAction', [
                 anotherWallet.address,
                 10,
               ]),
-              countryRestrictModule.address
-            )
+              countryRestrictModule.address,
+            ),
         ).to.eventually.be.fulfilled;
       });
     });
   });
 
-  describe(".moduleCheck", () => {
-    describe("when identity country is restricted", () => {
-      it("should return false", async () => {
+  describe('.moduleCheck', () => {
+    describe('when identity country is restricted', () => {
+      it('should return false', async () => {
         const {
           suite: { compliance, countryRestrictModule },
           accounts: { deployer, aliceWallet, bobWallet },
         } = await loadFixture(deployComplianceWithCountryRestrictModule);
-        const contract = await ethers.deployContract("MockContract");
+        const contract = await ethers.deployContract('MockContract');
         await compliance.bindToken(contract.address);
 
         await compliance
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchRestrictCountries(uint16[] calldata countries)",
-            ]).encodeFunctionData("batchRestrictCountries", [[42, 66]]),
-            countryRestrictModule.address
+              'function batchRestrictCountries(uint16[] calldata countries)',
+            ]).encodeFunctionData('batchRestrictCountries', [[42, 66]]),
+            countryRestrictModule.address,
           );
 
         await contract.setInvestorCountry(42);
@@ -581,28 +585,28 @@ describe("CountryRestrictModule", () => {
             aliceWallet.address,
             bobWallet.address,
             16,
-            compliance.address
-          )
+            compliance.address,
+          ),
         ).to.be.eventually.false;
       });
     });
 
-    describe("when identity country is not restricted", () => {
-      it("should return true", async () => {
+    describe('when identity country is not restricted', () => {
+      it('should return true', async () => {
         const {
           suite: { compliance, countryRestrictModule },
           accounts: { deployer, aliceWallet, bobWallet },
         } = await loadFixture(deployComplianceWithCountryRestrictModule);
-        const contract = await ethers.deployContract("MockContract");
+        const contract = await ethers.deployContract('MockContract');
         await compliance.bindToken(contract.address);
 
         await compliance
           .connect(deployer)
           .callModuleFunction(
             new ethers.utils.Interface([
-              "function batchRestrictCountries(uint16[] calldata countries)",
-            ]).encodeFunctionData("batchRestrictCountries", [[42, 66]]),
-            countryRestrictModule.address
+              'function batchRestrictCountries(uint16[] calldata countries)',
+            ]).encodeFunctionData('batchRestrictCountries', [[42, 66]]),
+            countryRestrictModule.address,
           );
 
         await contract.setInvestorCountry(10);
@@ -612,8 +616,8 @@ describe("CountryRestrictModule", () => {
             aliceWallet.address,
             bobWallet.address,
             16,
-            compliance.address
-          )
+            compliance.address,
+          ),
         ).to.be.eventually.true;
       });
     });

--- a/test/dvd.test.ts
+++ b/test/dvd.test.ts
@@ -1,25 +1,25 @@
-import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
-import { deployFullSuiteFixture } from "./fixtures/deploy-full-suite.fixture";
+import { deployFullSuiteFixture } from './fixtures/deploy-full-suite.fixture';
 
-describe("DVDTransferManager", () => {
+describe('DVDTransferManager', () => {
   async function deployFullSuiteWithTransferManager() {
     const context = await loadFixture(deployFullSuiteFixture);
 
-    const transferManager = await ethers.deployContract("DVDTransferManager");
+    const transferManager = await ethers.deployContract('DVDTransferManager');
 
-    const erc20A = await ethers.deployContract("TestERC20", [
-      "ERC20A",
-      "ERC20A",
+    const erc20A = await ethers.deployContract('TestERC20', [
+      'ERC20A',
+      'ERC20A',
     ]);
     await erc20A.mint(context.accounts.deployer.address, 1000);
 
-    const erc20B = await ethers.deployContract("TestERC20", [
-      "ERC20A",
-      "ERC20A",
+    const erc20B = await ethers.deployContract('TestERC20', [
+      'ERC20A',
+      'ERC20A',
     ]);
     await erc20B.mint(context.accounts.deployer.address, 1000);
 
@@ -30,7 +30,7 @@ describe("DVDTransferManager", () => {
         transferManager,
         erc20A,
         erc20B,
-        erc20C: await ethers.deployContract("TestERC20", ["ERC20C", "ERC20C"]),
+        erc20C: await ethers.deployContract('TestERC20', ['ERC20C', 'ERC20C']),
       },
     };
   }
@@ -53,13 +53,13 @@ describe("DVDTransferManager", () => {
         1000,
         context.accounts.bobWallet.address,
         context.suite.erc20B.address,
-        500
+        500,
       );
 
     const receipt = await tx.wait();
 
     const event = receipt.events.find(
-      (e) => e.event === "DVDTransferInitiated"
+      (e) => e.event === 'DVDTransferInitiated',
     );
     const transferId = event.args.transferID;
 
@@ -71,9 +71,9 @@ describe("DVDTransferManager", () => {
     };
   }
 
-  describe(".modifyFee()", () => {
-    describe("when sender is neither the DVD contract owner neither a TREX token owner", () => {
-      it("should revert", async () => {
+  describe('.modifyFee()', () => {
+    describe('when sender is neither the DVD contract owner neither a TREX token owner', () => {
+      it('should revert', async () => {
         const {
           suite: { transferManager, erc20A, erc20B },
           accounts: { anotherWallet, charlieWallet, davidWallet },
@@ -89,14 +89,14 @@ describe("DVDTransferManager", () => {
               1,
               1,
               charlieWallet.address,
-              davidWallet.address
-            )
-        ).to.be.revertedWith("Ownable: only owner can call");
+              davidWallet.address,
+            ),
+        ).to.be.revertedWith('Ownable: only owner can call');
       });
     });
 
-    describe("when sender is a TREX token owner", () => {
-      it("should revert for invalid fee settings", async () => {
+    describe('when sender is a TREX token owner', () => {
+      it('should revert for invalid fee settings', async () => {
         const {
           suite: { transferManager, token, erc20A },
           accounts: { deployer, charlieWallet, davidWallet },
@@ -112,12 +112,12 @@ describe("DVDTransferManager", () => {
               1,
               1,
               charlieWallet.address,
-              davidWallet.address
-            )
-        ).to.be.revertedWith("invalid fee settings");
+              davidWallet.address,
+            ),
+        ).to.be.revertedWith('invalid fee settings');
       });
 
-      it("should revert for invalid fee settings", async () => {
+      it('should revert for invalid fee settings', async () => {
         const {
           suite: { transferManager, token, erc20A },
           accounts: { deployer, charlieWallet, davidWallet },
@@ -133,16 +133,16 @@ describe("DVDTransferManager", () => {
               1,
               1,
               charlieWallet.address,
-              davidWallet.address
-            )
-        ).to.be.revertedWith("invalid fee settings");
+              davidWallet.address,
+            ),
+        ).to.be.revertedWith('invalid fee settings');
       });
     });
 
-    describe("when sender is the DVD contract owner", () => {
-      describe("when fee settings are not valid", () => {
-        describe("when fee1 is above max for feeBase", () => {
-          it("should revert", async () => {
+    describe('when sender is the DVD contract owner', () => {
+      describe('when fee settings are not valid', () => {
+        describe('when fee1 is above max for feeBase', () => {
+          it('should revert', async () => {
             const {
               suite: { transferManager, erc20A, erc20B },
               accounts: { deployer, charlieWallet, davidWallet },
@@ -158,14 +158,14 @@ describe("DVDTransferManager", () => {
                   1,
                   2,
                   charlieWallet.address,
-                  davidWallet.address
-                )
-            ).to.be.revertedWith("invalid fee settings");
+                  davidWallet.address,
+                ),
+            ).to.be.revertedWith('invalid fee settings');
           });
         });
 
-        describe("when fee2 is above max for feeBase", () => {
-          it("should revert", async () => {
+        describe('when fee2 is above max for feeBase', () => {
+          it('should revert', async () => {
             const {
               suite: { transferManager, erc20A, erc20B },
               accounts: { deployer, charlieWallet, davidWallet },
@@ -181,14 +181,14 @@ describe("DVDTransferManager", () => {
                   1000,
                   2,
                   charlieWallet.address,
-                  davidWallet.address
-                )
-            ).to.be.revertedWith("invalid fee settings");
+                  davidWallet.address,
+                ),
+            ).to.be.revertedWith('invalid fee settings');
           });
         });
 
-        describe("when feeBase is less than 2", () => {
-          it("should revert", async () => {
+        describe('when feeBase is less than 2', () => {
+          it('should revert', async () => {
             const {
               suite: { transferManager, erc20A, erc20B },
               accounts: { deployer, charlieWallet, davidWallet },
@@ -204,14 +204,14 @@ describe("DVDTransferManager", () => {
                   0,
                   1,
                   charlieWallet.address,
-                  davidWallet.address
-                )
-            ).to.be.revertedWith("invalid fee settings");
+                  davidWallet.address,
+                ),
+            ).to.be.revertedWith('invalid fee settings');
           });
         });
 
-        describe("when feeBase is more than 5", () => {
-          it("should revert", async () => {
+        describe('when feeBase is more than 5', () => {
+          it('should revert', async () => {
             const {
               suite: { transferManager, erc20A, erc20B },
               accounts: { deployer, charlieWallet, davidWallet },
@@ -227,14 +227,14 @@ describe("DVDTransferManager", () => {
                   1,
                   10,
                   charlieWallet.address,
-                  davidWallet.address
-                )
-            ).to.be.revertedWith("invalid fee settings");
+                  davidWallet.address,
+                ),
+            ).to.be.revertedWith('invalid fee settings');
           });
         });
 
-        describe("when fee1 is set, then fee1Wallet canot be zero address", () => {
-          it("should revert", async () => {
+        describe('when fee1 is set, then fee1Wallet canot be zero address', () => {
+          it('should revert', async () => {
             const {
               suite: { transferManager, erc20A, erc20B },
               accounts: { deployer, davidWallet },
@@ -250,14 +250,14 @@ describe("DVDTransferManager", () => {
                   0,
                   2,
                   ethers.constants.AddressZero,
-                  davidWallet.address
-                )
-            ).to.be.revertedWith("Fee wallet 1 must be valid");
+                  davidWallet.address,
+                ),
+            ).to.be.revertedWith('Fee wallet 1 must be valid');
           });
         });
 
-        describe("when fee2 is set, then fee2Wallet canot be zero address", () => {
-          it("should revert", async () => {
+        describe('when fee2 is set, then fee2Wallet canot be zero address', () => {
+          it('should revert', async () => {
             const {
               suite: { transferManager, erc20A, erc20B },
               accounts: { deployer },
@@ -273,15 +273,15 @@ describe("DVDTransferManager", () => {
                   1,
                   2,
                   ethers.constants.AddressZero,
-                  ethers.constants.AddressZero
-                )
-            ).to.be.revertedWith("Fee wallet 2 must be valid");
+                  ethers.constants.AddressZero,
+                ),
+            ).to.be.revertedWith('Fee wallet 2 must be valid');
           });
         });
       });
 
-      describe("when fee settings are valid", () => {
-        it("should set fee settings", async () => {
+      describe('when fee settings are valid', () => {
+        it('should set fee settings', async () => {
           const {
             suite: { transferManager, erc20A, erc20B },
             accounts: { deployer, charlieWallet, davidWallet },
@@ -296,16 +296,16 @@ describe("DVDTransferManager", () => {
               1,
               2,
               charlieWallet.address,
-              davidWallet.address
+              davidWallet.address,
             );
           await expect(tx)
-            .to.emit(transferManager, "FeeModified")
+            .to.emit(transferManager, 'FeeModified')
             .withArgs(
               ethers.utils.keccak256(
                 ethers.utils.defaultAbiCoder.encode(
-                  ["address", "address"],
-                  [erc20A.address, erc20B.address]
-                )
+                  ['address', 'address'],
+                  [erc20A.address, erc20B.address],
+                ),
               ),
               erc20A.address,
               erc20B.address,
@@ -313,16 +313,16 @@ describe("DVDTransferManager", () => {
               1,
               2,
               charlieWallet.address,
-              davidWallet.address
+              davidWallet.address,
             );
           await expect(tx)
-            .to.emit(transferManager, "FeeModified")
+            .to.emit(transferManager, 'FeeModified')
             .withArgs(
               ethers.utils.keccak256(
                 ethers.utils.defaultAbiCoder.encode(
-                  ["address", "address"],
-                  [erc20B.address, erc20A.address]
-                )
+                  ['address', 'address'],
+                  [erc20B.address, erc20A.address],
+                ),
               ),
               erc20B.address,
               erc20A.address,
@@ -330,11 +330,11 @@ describe("DVDTransferManager", () => {
               2,
               2,
               davidWallet.address,
-              charlieWallet.address
+              charlieWallet.address,
             );
         });
 
-        it("should set fee settings", async () => {
+        it('should set fee settings', async () => {
           const {
             suite: { transferManager, erc20A, erc20B },
             accounts: { deployer, charlieWallet },
@@ -349,16 +349,16 @@ describe("DVDTransferManager", () => {
               0,
               2,
               charlieWallet.address,
-              ethers.constants.AddressZero
+              ethers.constants.AddressZero,
             );
           await expect(tx)
-            .to.emit(transferManager, "FeeModified")
+            .to.emit(transferManager, 'FeeModified')
             .withArgs(
               ethers.utils.keccak256(
                 ethers.utils.defaultAbiCoder.encode(
-                  ["address", "address"],
-                  [erc20A.address, erc20B.address]
-                )
+                  ['address', 'address'],
+                  [erc20A.address, erc20B.address],
+                ),
               ),
               erc20A.address,
               erc20B.address,
@@ -366,16 +366,16 @@ describe("DVDTransferManager", () => {
               0,
               2,
               charlieWallet.address,
-              ethers.constants.AddressZero
+              ethers.constants.AddressZero,
             );
           await expect(tx)
-            .to.emit(transferManager, "FeeModified")
+            .to.emit(transferManager, 'FeeModified')
             .withArgs(
               ethers.utils.keccak256(
                 ethers.utils.defaultAbiCoder.encode(
-                  ["address", "address"],
-                  [erc20B.address, erc20A.address]
-                )
+                  ['address', 'address'],
+                  [erc20B.address, erc20A.address],
+                ),
               ),
               erc20B.address,
               erc20A.address,
@@ -383,16 +383,16 @@ describe("DVDTransferManager", () => {
               2,
               2,
               ethers.constants.AddressZero,
-              charlieWallet.address
+              charlieWallet.address,
             );
         });
       });
     });
   });
 
-  describe(".initiateDVDTransfer()", () => {
-    describe("when counterpart is zero address", () => {
-      it("should revert", async () => {
+  describe('.initiateDVDTransfer()', () => {
+    describe('when counterpart is zero address', () => {
+      it('should revert', async () => {
         const {
           suite: { transferManager, erc20A, erc20B },
           accounts: { deployer, charlieWallet },
@@ -410,14 +410,14 @@ describe("DVDTransferManager", () => {
               1000,
               ethers.constants.AddressZero,
               erc20B.address,
-              1000
-            )
-        ).to.be.revertedWith("counterpart cannot be null");
+              1000,
+            ),
+        ).to.be.revertedWith('counterpart cannot be null');
       });
     });
 
-    describe("when token2 has no supply", () => {
-      it("should revert", async () => {
+    describe('when token2 has no supply', () => {
+      it('should revert', async () => {
         const {
           suite: { transferManager, erc20A, erc20C },
           accounts: { deployer, charlieWallet, davidWallet },
@@ -435,14 +435,14 @@ describe("DVDTransferManager", () => {
               1000,
               davidWallet.address,
               erc20C.address,
-              1000
-            )
-        ).to.be.revertedWith("Invalid: not an ERC20 address");
+              1000,
+            ),
+        ).to.be.revertedWith('Invalid: not an ERC20 address');
       });
     });
 
-    describe("when transfer condition are met", () => {
-      it("should store an initiated transfer", async () => {
+    describe('when transfer condition are met', () => {
+      it('should store an initiated transfer', async () => {
         const {
           suite: { transferManager, erc20A, erc20B },
           accounts: { deployer, charlieWallet, davidWallet },
@@ -459,10 +459,10 @@ describe("DVDTransferManager", () => {
             1000,
             davidWallet.address,
             erc20B.address,
-            500
+            500,
           );
         await expect(tx)
-          .to.emit(transferManager, "DVDTransferInitiated")
+          .to.emit(transferManager, 'DVDTransferInitiated')
           .withArgs(
             anyValue,
             charlieWallet.address,
@@ -470,15 +470,15 @@ describe("DVDTransferManager", () => {
             1000,
             davidWallet.address,
             erc20B.address,
-            500
+            500,
           );
       });
     });
   });
 
-  describe(".cancelDVDTransfer()", () => {
-    describe("when transfer was not initiated", () => {
-      it("should revert", async () => {
+  describe('.cancelDVDTransfer()', () => {
+    describe('when transfer was not initiated', () => {
+      it('should revert', async () => {
         const {
           suite: { transferManager },
           accounts: { charlieWallet },
@@ -487,119 +487,119 @@ describe("DVDTransferManager", () => {
         await expect(
           transferManager
             .connect(charlieWallet)
-            .cancelDVDTransfer(ethers.constants.HashZero)
-        ).to.be.revertedWith("transfer ID does not exist");
+            .cancelDVDTransfer(ethers.constants.HashZero),
+        ).to.be.revertedWith('transfer ID does not exist');
       });
     });
 
-    describe("when sender is a wallet not related to the transfer", () => {
-      it("should revert", async () => {
+    describe('when sender is a wallet not related to the transfer', () => {
+      it('should revert', async () => {
         const {
           suite: { transferManager },
           accounts: { anotherWallet },
           values: { transferId },
         } = await loadFixture(
-          deployFullSuiteWithTransferManagerAndInitiatedTransfer
+          deployFullSuiteWithTransferManagerAndInitiatedTransfer,
         );
 
         await expect(
-          transferManager.connect(anotherWallet).cancelDVDTransfer(transferId)
-        ).to.be.revertedWith("Unauthorized to cancel transfer");
+          transferManager.connect(anotherWallet).cancelDVDTransfer(transferId),
+        ).to.be.revertedWith('Unauthorized to cancel transfer');
       });
     });
 
-    describe("when sender is the original initiator of the transfer", () => {
-      it("should cancel the transfer", async () => {
+    describe('when sender is the original initiator of the transfer', () => {
+      it('should cancel the transfer', async () => {
         const {
           suite: { transferManager },
           accounts: { aliceWallet },
           values: { transferId },
         } = await loadFixture(
-          deployFullSuiteWithTransferManagerAndInitiatedTransfer
+          deployFullSuiteWithTransferManagerAndInitiatedTransfer,
         );
 
         const tx = await transferManager
           .connect(aliceWallet)
           .cancelDVDTransfer(transferId);
         await expect(tx)
-          .to.emit(transferManager, "DVDTransferCancelled")
+          .to.emit(transferManager, 'DVDTransferCancelled')
           .withArgs(transferId);
         await expect(
-          transferManager.connect(aliceWallet).cancelDVDTransfer(transferId)
-        ).to.be.revertedWith("transfer ID does not exist");
+          transferManager.connect(aliceWallet).cancelDVDTransfer(transferId),
+        ).to.be.revertedWith('transfer ID does not exist');
       });
     });
 
-    describe("when sender is the original counterpart of the transfer", () => {
-      it("should cancel the transfer", async () => {
+    describe('when sender is the original counterpart of the transfer', () => {
+      it('should cancel the transfer', async () => {
         const {
           suite: { transferManager },
           accounts: { bobWallet },
           values: { transferId },
         } = await loadFixture(
-          deployFullSuiteWithTransferManagerAndInitiatedTransfer
+          deployFullSuiteWithTransferManagerAndInitiatedTransfer,
         );
 
         const tx = await transferManager
           .connect(bobWallet)
           .cancelDVDTransfer(transferId);
         await expect(tx)
-          .to.emit(transferManager, "DVDTransferCancelled")
+          .to.emit(transferManager, 'DVDTransferCancelled')
           .withArgs(transferId);
         await expect(
-          transferManager.connect(bobWallet).cancelDVDTransfer(transferId)
-        ).to.be.revertedWith("transfer ID does not exist");
+          transferManager.connect(bobWallet).cancelDVDTransfer(transferId),
+        ).to.be.revertedWith('transfer ID does not exist');
       });
     });
 
-    describe("when sender is the owner of the transfer manager contract", () => {
-      it("should cancel the transfer", async () => {
+    describe('when sender is the owner of the transfer manager contract', () => {
+      it('should cancel the transfer', async () => {
         const {
           suite: { transferManager },
           accounts: { deployer },
           values: { transferId },
         } = await loadFixture(
-          deployFullSuiteWithTransferManagerAndInitiatedTransfer
+          deployFullSuiteWithTransferManagerAndInitiatedTransfer,
         );
 
         const tx = await transferManager
           .connect(deployer)
           .cancelDVDTransfer(transferId);
         await expect(tx)
-          .to.emit(transferManager, "DVDTransferCancelled")
+          .to.emit(transferManager, 'DVDTransferCancelled')
           .withArgs(transferId);
         await expect(
-          transferManager.connect(deployer).cancelDVDTransfer(transferId)
-        ).to.be.revertedWith("transfer ID does not exist");
+          transferManager.connect(deployer).cancelDVDTransfer(transferId),
+        ).to.be.revertedWith('transfer ID does not exist');
       });
     });
 
-    describe("when sender is the owner of the TREX token 1 manager contract", () => {
-      it("should cancel the transfer", async () => {
+    describe('when sender is the owner of the TREX token 1 manager contract', () => {
+      it('should cancel the transfer', async () => {
         const {
           suite: { transferManager },
           accounts: { deployer },
           values: { transferId },
         } = await loadFixture(
-          deployFullSuiteWithTransferManagerAndInitiatedTransfer
+          deployFullSuiteWithTransferManagerAndInitiatedTransfer,
         );
 
         const tx = await transferManager
           .connect(deployer)
           .cancelDVDTransfer(transferId);
         await expect(tx)
-          .to.emit(transferManager, "DVDTransferCancelled")
+          .to.emit(transferManager, 'DVDTransferCancelled')
           .withArgs(transferId);
         await expect(
-          transferManager.connect(deployer).cancelDVDTransfer(transferId)
-        ).to.be.revertedWith("transfer ID does not exist");
+          transferManager.connect(deployer).cancelDVDTransfer(transferId),
+        ).to.be.revertedWith('transfer ID does not exist');
       });
     });
   });
 
-  describe(".takeDVDTransfer()", () => {
-    describe("when transfer was not initiated", () => {
-      it("should revert", async () => {
+  describe('.takeDVDTransfer()', () => {
+    describe('when transfer was not initiated', () => {
+      it('should revert', async () => {
         const {
           suite: { transferManager },
           accounts: { charlieWallet },
@@ -608,36 +608,36 @@ describe("DVDTransferManager", () => {
         await expect(
           transferManager
             .connect(charlieWallet)
-            .takeDVDTransfer(ethers.constants.HashZero)
-        ).to.be.revertedWith("transfer ID does not exist");
+            .takeDVDTransfer(ethers.constants.HashZero),
+        ).to.be.revertedWith('transfer ID does not exist');
       });
     });
 
-    describe("when transfer was initiated", () => {
-      describe("when sender is neither the counterpart neither a contract owner", () => {
-        it("should revert", async () => {
+    describe('when transfer was initiated', () => {
+      describe('when sender is neither the counterpart neither a contract owner', () => {
+        it('should revert', async () => {
           const {
             suite: { transferManager },
             accounts: { anotherWallet },
             values: { transferId },
           } = await loadFixture(
-            deployFullSuiteWithTransferManagerAndInitiatedTransfer
+            deployFullSuiteWithTransferManagerAndInitiatedTransfer,
           );
 
           await expect(
-            transferManager.connect(anotherWallet).takeDVDTransfer(transferId)
-          ).to.be.revertedWith("Must be counterpart or owner");
+            transferManager.connect(anotherWallet).takeDVDTransfer(transferId),
+          ).to.be.revertedWith('Must be counterpart or owner');
         });
       });
 
-      describe("when sender is the counterpart and transfer has fees", () => {
-        it("should execute the transfer with fees", async () => {
+      describe('when sender is the counterpart and transfer has fees', () => {
+        it('should execute the transfer with fees', async () => {
           const {
             suite: { transferManager, erc20A, erc20B },
             accounts: { aliceWallet, bobWallet, charlieWallet, davidWallet },
             values: { transferId },
           } = await loadFixture(
-            deployFullSuiteWithTransferManagerAndInitiatedTransfer
+            deployFullSuiteWithTransferManagerAndInitiatedTransfer,
           );
 
           await transferManager.modifyFee(
@@ -647,66 +647,66 @@ describe("DVDTransferManager", () => {
             2,
             2,
             charlieWallet.address,
-            davidWallet.address
+            davidWallet.address,
           );
 
           const tx = await transferManager
             .connect(bobWallet)
             .takeDVDTransfer(transferId);
           await expect(tx)
-            .to.emit(transferManager, "DVDTransferExecuted")
+            .to.emit(transferManager, 'DVDTransferExecuted')
             .withArgs(transferId);
           await expect(tx)
-            .to.emit(erc20A, "Transfer")
+            .to.emit(erc20A, 'Transfer')
             .withArgs(aliceWallet.address, bobWallet.address, 990);
           await expect(tx)
-            .to.emit(erc20A, "Transfer")
+            .to.emit(erc20A, 'Transfer')
             .withArgs(aliceWallet.address, charlieWallet.address, 10);
           await expect(tx)
-            .to.emit(erc20B, "Transfer")
+            .to.emit(erc20B, 'Transfer')
             .withArgs(bobWallet.address, aliceWallet.address, 490);
           await expect(tx)
-            .to.emit(erc20B, "Transfer")
+            .to.emit(erc20B, 'Transfer')
             .withArgs(bobWallet.address, davidWallet.address, 10);
           await expect(
-            transferManager.connect(bobWallet).takeDVDTransfer(transferId)
-          ).to.be.revertedWith("transfer ID does not exist");
+            transferManager.connect(bobWallet).takeDVDTransfer(transferId),
+          ).to.be.revertedWith('transfer ID does not exist');
         });
       });
 
-      describe("when sender is the counterpart and transfer has no fees", () => {
-        it("should execute the transfer without fees", async () => {
+      describe('when sender is the counterpart and transfer has no fees', () => {
+        it('should execute the transfer without fees', async () => {
           const {
             suite: { transferManager, erc20A, erc20B },
             accounts: { aliceWallet, bobWallet },
             values: { transferId },
           } = await loadFixture(
-            deployFullSuiteWithTransferManagerAndInitiatedTransfer
+            deployFullSuiteWithTransferManagerAndInitiatedTransfer,
           );
 
           const tx = await transferManager
             .connect(bobWallet)
             .takeDVDTransfer(transferId);
           await expect(tx)
-            .to.emit(transferManager, "DVDTransferExecuted")
+            .to.emit(transferManager, 'DVDTransferExecuted')
             .withArgs(transferId);
           await expect(tx)
-            .to.emit(erc20A, "Transfer")
+            .to.emit(erc20A, 'Transfer')
             .withArgs(aliceWallet.address, bobWallet.address, 1000);
           await expect(tx)
-            .to.emit(erc20B, "Transfer")
+            .to.emit(erc20B, 'Transfer')
             .withArgs(bobWallet.address, aliceWallet.address, 500);
           await expect(
-            transferManager.connect(bobWallet).takeDVDTransfer(transferId)
-          ).to.be.revertedWith("transfer ID does not exist");
+            transferManager.connect(bobWallet).takeDVDTransfer(transferId),
+          ).to.be.revertedWith('transfer ID does not exist');
         });
       });
     });
   });
 
-  describe(".isTREXAgent()", () => {
-    describe("when address is not a TREX agent", () => {
-      it("should return false", async () => {
+  describe('.isTREXAgent()', () => {
+    describe('when address is not a TREX agent', () => {
+      it('should return false', async () => {
         const {
           suite: { transferManager, token },
           accounts: { anotherWallet },
@@ -715,29 +715,29 @@ describe("DVDTransferManager", () => {
         expect(
           await transferManager.isTREXAgent(
             token.address,
-            anotherWallet.address
-          )
+            anotherWallet.address,
+          ),
         ).to.be.false;
       });
     });
 
-    describe("when address is a TREX agent", () => {
-      it("should return true", async () => {
+    describe('when address is a TREX agent', () => {
+      it('should return true', async () => {
         const {
           suite: { transferManager, token },
           accounts: { tokenAgent },
         } = await loadFixture(deployFullSuiteWithTransferManager);
 
         expect(
-          await transferManager.isTREXAgent(token.address, tokenAgent.address)
+          await transferManager.isTREXAgent(token.address, tokenAgent.address),
         ).to.be.true;
       });
     });
   });
 
-  describe(".isTREXOwner()", () => {
-    describe("when address is not a TREX owner", () => {
-      it("should return false", async () => {
+  describe('.isTREXOwner()', () => {
+    describe('when address is not a TREX owner', () => {
+      it('should return false', async () => {
         const {
           suite: { transferManager, token },
           accounts: { anotherWallet },
@@ -746,29 +746,29 @@ describe("DVDTransferManager", () => {
         expect(
           await transferManager.isTREXOwner(
             token.address,
-            anotherWallet.address
-          )
+            anotherWallet.address,
+          ),
         ).to.be.false;
       });
     });
 
-    describe("when address is a TREX agent", () => {
-      it("should return true", async () => {
+    describe('when address is a TREX agent', () => {
+      it('should return true', async () => {
         const {
           suite: { transferManager, token },
           accounts: { deployer },
         } = await loadFixture(deployFullSuiteWithTransferManager);
 
         expect(
-          await transferManager.isTREXOwner(token.address, deployer.address)
+          await transferManager.isTREXOwner(token.address, deployer.address),
         ).to.be.true;
       });
     });
   });
 
-  describe(".isTREXToken()", () => {
-    describe("When token does not have an Identity Registry (probably not a ERC3643 token", () => {
-      it("should return false", async () => {
+  describe('.isTREXToken()', () => {
+    describe('When token does not have an Identity Registry (probably not a ERC3643 token', () => {
+      it('should return false', async () => {
         const {
           suite: { transferManager, token },
         } = await loadFixture(deployFullSuiteWithTransferManager);

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1,14 +1,14 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
-import { deployFullSuiteFixture } from "./fixtures/deploy-full-suite.fixture";
-import { Event } from "ethers";
+import { deployFullSuiteFixture } from './fixtures/deploy-full-suite.fixture';
+import { Event } from 'ethers';
 
-describe("TREXFactory", () => {
-  describe(".deployTREXSuite()", () => {
-    describe("when called by not owner", () => {
-      it("should revert", async () => {
+describe('TREXFactory', () => {
+  describe('.deployTREXSuite()', () => {
+    describe('when called by not owner', () => {
+      it('should revert', async () => {
         const {
           accounts: { deployer, anotherWallet },
           factories: { trexFactory },
@@ -16,11 +16,11 @@ describe("TREXFactory", () => {
 
         await expect(
           trexFactory.connect(anotherWallet).deployTREXSuite(
-            "salt",
+            'salt',
             {
               owner: deployer.address,
-              name: "Token name",
-              symbol: "SYM",
+              name: 'Token name',
+              symbol: 'SYM',
               decimals: 8,
               irs: ethers.constants.AddressZero,
               ONCHAINID: ethers.constants.AddressZero,
@@ -33,26 +33,26 @@ describe("TREXFactory", () => {
               claimTopics: [],
               issuers: [],
               issuerClaims: [],
-            }
-          )
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            },
+          ),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when called by owner", () => {
-      describe("when salt was already used", () => {
-        it("should revert", async () => {
+    describe('when called by owner', () => {
+      describe('when salt was already used', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             factories: { trexFactory },
           } = await loadFixture(deployFullSuiteFixture);
 
           await trexFactory.connect(deployer).deployTREXSuite(
-            "salt",
+            'salt',
             {
               owner: deployer.address,
-              name: "Token name",
-              symbol: "SYM",
+              name: 'Token name',
+              symbol: 'SYM',
               decimals: 8,
               irs: ethers.constants.AddressZero,
               ONCHAINID: ethers.constants.AddressZero,
@@ -65,16 +65,16 @@ describe("TREXFactory", () => {
               claimTopics: [],
               issuers: [],
               issuerClaims: [],
-            }
+            },
           );
 
           await expect(
             trexFactory.connect(deployer).deployTREXSuite(
-              "salt",
+              'salt',
               {
                 owner: deployer.address,
-                name: "Token name",
-                symbol: "SYM",
+                name: 'Token name',
+                symbol: 'SYM',
                 decimals: 8,
                 irs: ethers.constants.AddressZero,
                 ONCHAINID: ethers.constants.AddressZero,
@@ -87,14 +87,14 @@ describe("TREXFactory", () => {
                 claimTopics: [],
                 issuers: [],
                 issuerClaims: [],
-              }
-            )
-          ).to.be.revertedWith("token already deployed");
+              },
+            ),
+          ).to.be.revertedWith('token already deployed');
         });
       });
 
-      describe("when claim pattern is not valid", () => {
-        it("should revert", async () => {
+      describe('when claim pattern is not valid', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             factories: { trexFactory },
@@ -102,11 +102,11 @@ describe("TREXFactory", () => {
 
           await expect(
             trexFactory.connect(deployer).deployTREXSuite(
-              "salt",
+              'salt',
               {
                 owner: deployer.address,
-                name: "Token name",
-                symbol: "SYM",
+                name: 'Token name',
+                symbol: 'SYM',
                 decimals: 8,
                 irs: ethers.constants.AddressZero,
                 ONCHAINID: ethers.constants.AddressZero,
@@ -119,14 +119,14 @@ describe("TREXFactory", () => {
                 claimTopics: [],
                 issuers: [ethers.constants.AddressZero],
                 issuerClaims: [],
-              }
-            )
-          ).to.be.revertedWith("claim pattern not valid");
+              },
+            ),
+          ).to.be.revertedWith('claim pattern not valid');
         });
       });
 
-      describe("when configuring more than 5 claim issuers", () => {
-        it("should revert", async () => {
+      describe('when configuring more than 5 claim issuers', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             factories: { trexFactory },
@@ -134,11 +134,11 @@ describe("TREXFactory", () => {
 
           await expect(
             trexFactory.connect(deployer).deployTREXSuite(
-              "salt",
+              'salt',
               {
                 owner: deployer.address,
-                name: "Token name",
-                symbol: "SYM",
+                name: 'Token name',
+                symbol: 'SYM',
                 decimals: 8,
                 irs: ethers.constants.AddressZero,
                 ONCHAINID: ethers.constants.AddressZero,
@@ -151,17 +151,17 @@ describe("TREXFactory", () => {
                 claimTopics: [],
                 issuers: Array.from(
                   { length: 6 },
-                  () => ethers.constants.AddressZero
+                  () => ethers.constants.AddressZero,
                 ),
                 issuerClaims: Array.from({ length: 6 }, () => []),
-              }
-            )
-          ).to.be.revertedWith("max 5 claim issuers at deployment");
+              },
+            ),
+          ).to.be.revertedWith('max 5 claim issuers at deployment');
         });
       });
 
-      describe("when configuring more than 5 claim topics", () => {
-        it("should revert", async () => {
+      describe('when configuring more than 5 claim topics', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             factories: { trexFactory },
@@ -169,11 +169,11 @@ describe("TREXFactory", () => {
 
           await expect(
             trexFactory.connect(deployer).deployTREXSuite(
-              "salt",
+              'salt',
               {
                 owner: deployer.address,
-                name: "Token name",
-                symbol: "SYM",
+                name: 'Token name',
+                symbol: 'SYM',
                 decimals: 8,
                 irs: ethers.constants.AddressZero,
                 ONCHAINID: ethers.constants.AddressZero,
@@ -185,18 +185,18 @@ describe("TREXFactory", () => {
               {
                 claimTopics: Array.from(
                   { length: 6 },
-                  () => ethers.constants.HashZero
+                  () => ethers.constants.HashZero,
                 ),
                 issuers: [],
                 issuerClaims: [],
-              }
-            )
-          ).to.be.revertedWith("max 5 claim topics at deployment");
+              },
+            ),
+          ).to.be.revertedWith('max 5 claim topics at deployment');
         });
       });
 
-      describe("when configuring more than 5 agents", () => {
-        it("should revert", async () => {
+      describe('when configuring more than 5 agents', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             factories: { trexFactory },
@@ -204,17 +204,17 @@ describe("TREXFactory", () => {
 
           await expect(
             trexFactory.connect(deployer).deployTREXSuite(
-              "salt",
+              'salt',
               {
                 owner: deployer.address,
-                name: "Token name",
-                symbol: "SYM",
+                name: 'Token name',
+                symbol: 'SYM',
                 decimals: 8,
                 irs: ethers.constants.AddressZero,
                 ONCHAINID: ethers.constants.AddressZero,
                 irAgents: Array.from(
                   { length: 6 },
-                  () => ethers.constants.AddressZero
+                  () => ethers.constants.AddressZero,
                 ),
                 tokenAgents: [],
                 complianceModules: [],
@@ -224,14 +224,14 @@ describe("TREXFactory", () => {
                 claimTopics: [],
                 issuers: [],
                 issuerClaims: [],
-              }
-            )
-          ).to.be.revertedWith("max 5 agents at deployment");
+              },
+            ),
+          ).to.be.revertedWith('max 5 agents at deployment');
         });
       });
 
-      describe("when configuring more than 30 compliance modules", () => {
-        it("should revert", async () => {
+      describe('when configuring more than 30 compliance modules', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             factories: { trexFactory },
@@ -239,11 +239,11 @@ describe("TREXFactory", () => {
 
           await expect(
             trexFactory.connect(deployer).deployTREXSuite(
-              "salt",
+              'salt',
               {
                 owner: deployer.address,
-                name: "Token name",
-                symbol: "SYM",
+                name: 'Token name',
+                symbol: 'SYM',
                 decimals: 8,
                 irs: ethers.constants.AddressZero,
                 ONCHAINID: ethers.constants.AddressZero,
@@ -251,7 +251,7 @@ describe("TREXFactory", () => {
                 tokenAgents: [],
                 complianceModules: Array.from(
                   { length: 31 },
-                  () => ethers.constants.AddressZero
+                  () => ethers.constants.AddressZero,
                 ),
                 complianceSettings: [],
               },
@@ -259,14 +259,14 @@ describe("TREXFactory", () => {
                 claimTopics: [],
                 issuers: [],
                 issuerClaims: [],
-              }
-            )
-          ).to.be.revertedWith("max 30 module actions at deployment");
+              },
+            ),
+          ).to.be.revertedWith('max 30 module actions at deployment');
         });
       });
 
-      describe("when compliance configuration is not valid", () => {
-        it("should revert", async () => {
+      describe('when compliance configuration is not valid', () => {
+        it('should revert', async () => {
           const {
             accounts: { deployer },
             factories: { trexFactory },
@@ -274,31 +274,31 @@ describe("TREXFactory", () => {
 
           await expect(
             trexFactory.connect(deployer).deployTREXSuite(
-              "salt",
+              'salt',
               {
                 owner: deployer.address,
-                name: "Token name",
-                symbol: "SYM",
+                name: 'Token name',
+                symbol: 'SYM',
                 decimals: 8,
                 irs: ethers.constants.AddressZero,
                 ONCHAINID: ethers.constants.AddressZero,
                 irAgents: [],
                 tokenAgents: [],
                 complianceModules: [],
-                complianceSettings: ["0x00"],
+                complianceSettings: ['0x00'],
               },
               {
                 claimTopics: [],
                 issuers: [],
                 issuerClaims: [],
-              }
-            )
-          ).to.be.revertedWith("invalid compliance pattern");
+              },
+            ),
+          ).to.be.revertedWith('invalid compliance pattern');
         });
       });
 
-      describe("when configuration is valid", () => {
-        it("should deploy a new suite", async () => {
+      describe('when configuration is valid', () => {
+        it('should deploy a new suite', async () => {
           const {
             accounts: { deployer, aliceWallet, bobWallet },
             factories: { trexFactory },
@@ -306,15 +306,15 @@ describe("TREXFactory", () => {
           } = await loadFixture(deployFullSuiteFixture);
 
           const countryAllowModule = await ethers.deployContract(
-            "CountryAllowModule"
+            'CountryAllowModule',
           );
 
           const tx = await trexFactory.connect(deployer).deployTREXSuite(
-            "salt",
+            'salt',
             {
               owner: deployer.address,
-              name: "Token name",
-              symbol: "SYM",
+              name: 'Token name',
+              symbol: 'SYM',
               decimals: 8,
               irs: ethers.constants.AddressZero,
               ONCHAINID: ethers.constants.AddressZero,
@@ -323,44 +323,44 @@ describe("TREXFactory", () => {
               complianceModules: [countryAllowModule.address],
               complianceSettings: [
                 new ethers.utils.Interface([
-                  "function batchAllowCountries(uint16[] calldata countries)",
-                ]).encodeFunctionData("batchAllowCountries", [[42, 66]]),
+                  'function batchAllowCountries(uint16[] calldata countries)',
+                ]).encodeFunctionData('batchAllowCountries', [[42, 66]]),
               ],
             },
             {
               claimTopics: [
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("DEMO_TOPIC")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('DEMO_TOPIC')),
               ],
               issuers: [claimIssuerContract.address],
               issuerClaims: [
                 [
                   ethers.utils.keccak256(
-                    ethers.utils.toUtf8Bytes("DEMO_TOPIC")
+                    ethers.utils.toUtf8Bytes('DEMO_TOPIC'),
                   ),
                 ],
               ],
-            }
+            },
           );
-          expect(tx).to.emit(trexFactory, "TREXSuiteDeployed");
+          expect(tx).to.emit(trexFactory, 'TREXSuiteDeployed');
         });
       });
     });
   });
 
-  describe(".getToken()", () => {
-    describe("when salt was used to deploy a token", () => {
-      it("should return the token address", async () => {
+  describe('.getToken()', () => {
+    describe('when salt was used to deploy a token', () => {
+      it('should return the token address', async () => {
         const {
           accounts: { deployer },
           factories: { trexFactory },
         } = await loadFixture(deployFullSuiteFixture);
 
         const tx = await trexFactory.connect(deployer).deployTREXSuite(
-          "salt",
+          'salt',
           {
             owner: deployer.address,
-            name: "Token name",
-            symbol: "SYM",
+            name: 'Token name',
+            symbol: 'SYM',
             decimals: 8,
             irs: ethers.constants.AddressZero,
             ONCHAINID: ethers.constants.AddressZero,
@@ -373,34 +373,34 @@ describe("TREXFactory", () => {
             claimTopics: [],
             issuers: [],
             issuerClaims: [],
-          }
+          },
         );
 
         const receipt = await tx.wait();
         const tokenAddressExpected = receipt.events.find(
-          (event: Event) => event.event === "TREXSuiteDeployed"
+          (event: Event) => event.event === 'TREXSuiteDeployed',
         ).args[0];
 
-        const tokenAddress = await trexFactory.getToken("salt");
+        const tokenAddress = await trexFactory.getToken('salt');
         expect(tokenAddress).to.equal(tokenAddressExpected);
       });
     });
   });
 
-  describe(".recoverContractOwnership()", () => {
-    describe("when sender is not owner", () => {
-      it("should revert", async () => {
+  describe('.recoverContractOwnership()', () => {
+    describe('when sender is not owner', () => {
+      it('should revert', async () => {
         const {
           accounts: { deployer, aliceWallet },
           factories: { trexFactory },
         } = await loadFixture(deployFullSuiteFixture);
 
         const tx = await trexFactory.connect(deployer).deployTREXSuite(
-          "salt",
+          'salt',
           {
             owner: deployer.address,
-            name: "Token name",
-            symbol: "SYM",
+            name: 'Token name',
+            symbol: 'SYM',
             decimals: 8,
             irs: ethers.constants.AddressZero,
             ONCHAINID: ethers.constants.AddressZero,
@@ -413,35 +413,35 @@ describe("TREXFactory", () => {
             claimTopics: [],
             issuers: [],
             issuerClaims: [],
-          }
+          },
         );
 
         const receipt = await tx.wait();
         const tokenAddress = receipt.events.find(
-          (event: Event) => event.event === "TREXSuiteDeployed"
+          (event: Event) => event.event === 'TREXSuiteDeployed',
         ).args[0];
 
         await expect(
           trexFactory
             .connect(aliceWallet)
-            .recoverContractOwnership(tokenAddress, aliceWallet.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .recoverContractOwnership(tokenAddress, aliceWallet.address),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is owner and factory owns the trex contract", () => {
-      it("should transfer ownership on the desired contract", async () => {
+    describe('when sender is owner and factory owns the trex contract', () => {
+      it('should transfer ownership on the desired contract', async () => {
         const {
           accounts: { deployer, aliceWallet },
           factories: { trexFactory },
         } = await loadFixture(deployFullSuiteFixture);
 
         const deployTx = await trexFactory.connect(deployer).deployTREXSuite(
-          "salt",
+          'salt',
           {
             owner: trexFactory.address,
-            name: "Token name",
-            symbol: "SYM",
+            name: 'Token name',
+            symbol: 'SYM',
             decimals: 8,
             irs: ethers.constants.AddressZero,
             ONCHAINID: ethers.constants.AddressZero,
@@ -454,22 +454,22 @@ describe("TREXFactory", () => {
             claimTopics: [],
             issuers: [],
             issuerClaims: [],
-          }
+          },
         );
 
         const receipt = await deployTx.wait();
         const tokenAddress = receipt.events.find(
-          (event: Event) => event.event === "TREXSuiteDeployed"
+          (event: Event) => event.event === 'TREXSuiteDeployed',
         ).args[0];
 
         const tx = await trexFactory
           .connect(deployer)
           .recoverContractOwnership(tokenAddress, aliceWallet.address);
 
-        const token = await ethers.getContractAt("Token", tokenAddress);
+        const token = await ethers.getContractAt('Token', tokenAddress);
 
         await expect(tx)
-          .to.emit(token, "OwnershipTransferred")
+          .to.emit(token, 'OwnershipTransferred')
           .withArgs(trexFactory.address, aliceWallet.address);
 
         await expect(token.owner()).to.eventually.eq(aliceWallet.address);

--- a/test/fixtures/deploy-compliance.fixture.ts
+++ b/test/fixtures/deploy-compliance.fixture.ts
@@ -1,10 +1,10 @@
-import { ethers } from "hardhat";
+import { ethers } from 'hardhat';
 
 export async function deployComplianceFixture() {
   const [deployer, aliceWallet, bobWallet, anotherWallet] =
     await ethers.getSigners();
 
-  const compliance = await ethers.deployContract("ModularCompliance");
+  const compliance = await ethers.deployContract('ModularCompliance');
   await compliance.init();
 
   return {

--- a/test/fixtures/deploy-full-suite.fixture.ts
+++ b/test/fixtures/deploy-full-suite.fixture.ts
@@ -1,20 +1,20 @@
-import { BigNumber, Contract, Signer } from "ethers";
-import { ethers } from "hardhat";
-import OnchainID from "@onchain-id/solidity";
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { BigNumber, Contract, Signer } from 'ethers';
+import { ethers } from 'hardhat';
+import OnchainID from '@onchain-id/solidity';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 
 export async function deployIdentityProxy(
-  implementationAuthority: Contract["address"],
+  implementationAuthority: Contract['address'],
   managementKey: string,
-  signer: Signer
+  signer: Signer,
 ) {
   const identity = await new ethers.ContractFactory(
     OnchainID.contracts.IdentityProxy.abi,
     OnchainID.contracts.IdentityProxy.bytecode,
-    signer
+    signer,
   ).deploy(implementationAuthority, managementKey);
 
-  return ethers.getContractAt("Identity", identity.address, signer);
+  return ethers.getContractAt('Identity', identity.address, signer);
 }
 
 export async function deployFullSuiteFixture() {
@@ -35,42 +35,42 @@ export async function deployFullSuiteFixture() {
 
   // Deploy implementations
   const claimTopicsRegistryImplementation = await ethers.deployContract(
-    "ClaimTopicsRegistry",
-    deployer
+    'ClaimTopicsRegistry',
+    deployer,
   );
   const trustedIssuersRegistryImplementation = await ethers.deployContract(
-    "TrustedIssuersRegistry",
-    deployer
+    'TrustedIssuersRegistry',
+    deployer,
   );
   const identityRegistryStorageImplementation = await ethers.deployContract(
-    "IdentityRegistryStorage",
-    deployer
+    'IdentityRegistryStorage',
+    deployer,
   );
   const identityRegistryImplementation = await ethers.deployContract(
-    "IdentityRegistry",
-    deployer
+    'IdentityRegistry',
+    deployer,
   );
   const modularComplianceImplementation = await ethers.deployContract(
-    "ModularCompliance",
-    deployer
+    'ModularCompliance',
+    deployer,
   );
-  const tokenImplementation = await ethers.deployContract("Token", deployer);
+  const tokenImplementation = await ethers.deployContract('Token', deployer);
   const identityImplementation = await new ethers.ContractFactory(
     OnchainID.contracts.Identity.abi,
     OnchainID.contracts.Identity.bytecode,
-    deployer
+    deployer,
   ).deploy(deployer.address, true);
 
   const identityImplementationAuthority = await new ethers.ContractFactory(
     OnchainID.contracts.ImplementationAuthority.abi,
     OnchainID.contracts.ImplementationAuthority.bytecode,
-    deployer
+    deployer,
   ).deploy(identityImplementation.address);
 
   const trexImplementationAuthority = await ethers.deployContract(
-    "TREXImplementationAuthority",
+    'TREXImplementationAuthority',
     [true, ethers.constants.AddressZero, ethers.constants.AddressZero],
-    deployer
+    deployer,
   );
   const versionStruct = {
     major: 4,
@@ -90,72 +90,72 @@ export async function deployFullSuiteFixture() {
     .addAndUseTREXVersion(versionStruct, contractsStruct);
 
   const trexFactory = await ethers.deployContract(
-    "TREXFactory",
+    'TREXFactory',
     [trexImplementationAuthority.address],
-    deployer
+    deployer,
   );
 
   const claimTopicsRegistry = await ethers
     .deployContract(
-      "ClaimTopicsRegistryProxy",
+      'ClaimTopicsRegistryProxy',
       [trexImplementationAuthority.address],
-      deployer
+      deployer,
     )
     .then(async (proxy) =>
-      ethers.getContractAt("ClaimTopicsRegistry", proxy.address)
+      ethers.getContractAt('ClaimTopicsRegistry', proxy.address),
     );
 
   const trustedIssuersRegistry = await ethers
     .deployContract(
-      "TrustedIssuersRegistryProxy",
+      'TrustedIssuersRegistryProxy',
       [trexImplementationAuthority.address],
-      deployer
+      deployer,
     )
     .then(async (proxy) =>
-      ethers.getContractAt("TrustedIssuersRegistry", proxy.address)
+      ethers.getContractAt('TrustedIssuersRegistry', proxy.address),
     );
 
   const identityRegistryStorage = await ethers
     .deployContract(
-      "IdentityRegistryStorageProxy",
+      'IdentityRegistryStorageProxy',
       [trexImplementationAuthority.address],
-      deployer
+      deployer,
     )
     .then(async (proxy) =>
-      ethers.getContractAt("IdentityRegistryStorage", proxy.address)
+      ethers.getContractAt('IdentityRegistryStorage', proxy.address),
     );
 
   const defaultCompliance = await ethers.deployContract(
-    "DefaultCompliance",
-    deployer
+    'DefaultCompliance',
+    deployer,
   );
 
   const identityRegistry = await ethers
     .deployContract(
-      "IdentityRegistryProxy",
+      'IdentityRegistryProxy',
       [
         trexImplementationAuthority.address,
         trustedIssuersRegistry.address,
         claimTopicsRegistry.address,
         identityRegistryStorage.address,
       ],
-      deployer
+      deployer,
     )
     .then(async (proxy) =>
-      ethers.getContractAt("IdentityRegistry", proxy.address)
+      ethers.getContractAt('IdentityRegistry', proxy.address),
     );
 
   const tokenOID = await deployIdentityProxy(
     identityImplementationAuthority.address,
     tokenIssuer.address,
-    deployer
+    deployer,
   );
-  const tokenName = "TREXDINO";
-  const tokenSymbol = "TREX";
-  const tokenDecimals = BigNumber.from("0");
+  const tokenName = 'TREXDINO';
+  const tokenSymbol = 'TREX';
+  const tokenDecimals = BigNumber.from('0');
   const token = await ethers
     .deployContract(
-      "TokenProxy",
+      'TokenProxy',
       [
         trexImplementationAuthority.address,
         identityRegistry.address,
@@ -165,14 +165,14 @@ export async function deployFullSuiteFixture() {
         tokenDecimals,
         tokenOID.address,
       ],
-      deployer
+      deployer,
     )
-    .then(async (proxy) => ethers.getContractAt("Token", proxy.address));
+    .then(async (proxy) => ethers.getContractAt('Token', proxy.address));
 
   const agentManager = await ethers.deployContract(
-    "AgentManager",
+    'AgentManager',
     [token.address],
-    tokenAgent
+    tokenAgent,
   );
 
   await identityRegistryStorage
@@ -181,25 +181,25 @@ export async function deployFullSuiteFixture() {
 
   await token.connect(deployer).addAgent(tokenAgent.address);
 
-  const claimTopics = [ethers.utils.id("CLAIM_TOPIC")];
+  const claimTopics = [ethers.utils.id('CLAIM_TOPIC')];
   await claimTopicsRegistry.connect(deployer).addClaimTopic(claimTopics[0]);
 
   const claimIssuerContract = await ethers.deployContract(
-    "ClaimIssuer",
+    'ClaimIssuer',
     [claimIssuer.address],
-    claimIssuer
+    claimIssuer,
   );
   await claimIssuerContract
     .connect(claimIssuer)
     .addKey(
       ethers.utils.keccak256(
         ethers.utils.defaultAbiCoder.encode(
-          ["address"],
-          [claimIssuerSigningKey.address]
-        )
+          ['address'],
+          [claimIssuerSigningKey.address],
+        ),
       ),
       3,
-      1
+      1,
     );
 
   await trustedIssuersRegistry
@@ -209,29 +209,29 @@ export async function deployFullSuiteFixture() {
   const aliceIdentity = await deployIdentityProxy(
     identityImplementationAuthority.address,
     aliceWallet.address,
-    deployer
+    deployer,
   );
   await aliceIdentity
     .connect(aliceWallet)
     .addKey(
       ethers.utils.keccak256(
         ethers.utils.defaultAbiCoder.encode(
-          ["address"],
-          [aliceActionKey.address]
-        )
+          ['address'],
+          [aliceActionKey.address],
+        ),
       ),
       2,
-      1
+      1,
     );
   const bobIdentity = await deployIdentityProxy(
     identityImplementationAuthority.address,
     bobWallet.address,
-    deployer
+    deployer,
   );
   const charlieIdentity = await deployIdentityProxy(
     identityImplementationAuthority.address,
     charlieWallet.address,
-    deployer
+    deployer,
   );
 
   await identityRegistry.connect(deployer).addAgent(tokenAgent.address);
@@ -242,28 +242,28 @@ export async function deployFullSuiteFixture() {
     .batchRegisterIdentity(
       [aliceWallet.address, bobWallet.address],
       [aliceIdentity.address, bobIdentity.address],
-      [42, 666]
+      [42, 666],
     );
 
   const claimForAlice = {
     data: ethers.utils.hexlify(
-      ethers.utils.toUtf8Bytes("Some claim public data.")
+      ethers.utils.toUtf8Bytes('Some claim public data.'),
     ),
     issuer: claimIssuerContract.address,
     topic: claimTopics[0],
     scheme: 1,
     identity: aliceIdentity.address,
-    signature: "",
+    signature: '',
   };
   claimForAlice.signature = await claimIssuerSigningKey.signMessage(
     ethers.utils.arrayify(
       ethers.utils.keccak256(
         ethers.utils.defaultAbiCoder.encode(
-          ["address", "uint256", "bytes"],
-          [claimForAlice.identity, claimForAlice.topic, claimForAlice.data]
-        )
-      )
-    )
+          ['address', 'uint256', 'bytes'],
+          [claimForAlice.identity, claimForAlice.topic, claimForAlice.data],
+        ),
+      ),
+    ),
   );
 
   await aliceIdentity
@@ -274,28 +274,28 @@ export async function deployFullSuiteFixture() {
       claimForAlice.issuer,
       claimForAlice.signature,
       claimForAlice.data,
-      ""
+      '',
     );
 
   const claimForBob = {
     data: ethers.utils.hexlify(
-      ethers.utils.toUtf8Bytes("Some claim public data.")
+      ethers.utils.toUtf8Bytes('Some claim public data.'),
     ),
     issuer: claimIssuerContract.address,
     topic: claimTopics[0],
     scheme: 1,
     identity: bobIdentity.address,
-    signature: "",
+    signature: '',
   };
   claimForBob.signature = await claimIssuerSigningKey.signMessage(
     ethers.utils.arrayify(
       ethers.utils.keccak256(
         ethers.utils.defaultAbiCoder.encode(
-          ["address", "uint256", "bytes"],
-          [claimForBob.identity, claimForBob.topic, claimForBob.data]
-        )
-      )
-    )
+          ['address', 'uint256', 'bytes'],
+          [claimForBob.identity, claimForBob.topic, claimForBob.data],
+        ),
+      ),
+    ),
   );
 
   await bobIdentity
@@ -306,7 +306,7 @@ export async function deployFullSuiteFixture() {
       claimForBob.issuer,
       claimForBob.signature,
       claimForBob.data,
-      ""
+      '',
     );
 
   await token.connect(tokenAgent).mint(aliceWallet.address, 1000);
@@ -372,15 +372,15 @@ export async function deploySuiteWithModularCompliancesFixture() {
   const context = await loadFixture(deployFullSuiteFixture);
 
   const complianceProxy = await ethers.deployContract(
-    "ModularComplianceProxy",
-    [context.authorities.trexImplementationAuthority.address]
+    'ModularComplianceProxy',
+    [context.authorities.trexImplementationAuthority.address],
   );
   const compliance = await ethers.getContractAt(
-    "ModularCompliance",
-    complianceProxy.address
+    'ModularCompliance',
+    complianceProxy.address,
   );
 
-  const complianceBeta = await ethers.deployContract("ModularCompliance");
+  const complianceBeta = await ethers.deployContract('ModularCompliance');
   await complianceBeta.init();
 
   return {
@@ -396,12 +396,12 @@ export async function deploySuiteWithModularCompliancesFixture() {
 export async function deploySuiteWithModuleComplianceBoundToWallet() {
   const context = await loadFixture(deployFullSuiteFixture);
 
-  const compliance = await ethers.deployContract("ModularCompliance");
+  const compliance = await ethers.deployContract('ModularCompliance');
   await compliance.init();
 
-  const complianceModuleA = await ethers.deployContract("CountryAllowModule");
+  const complianceModuleA = await ethers.deployContract('CountryAllowModule');
   await compliance.addModule(complianceModuleA.address);
-  const complianceModuleB = await ethers.deployContract("CountryAllowModule");
+  const complianceModuleB = await ethers.deployContract('CountryAllowModule');
   await compliance.addModule(complianceModuleB.address);
 
   await compliance.bindToken(context.accounts.charlieWallet.address);

--- a/test/registries/claim-topics-registry.test.ts
+++ b/test/registries/claim-topics-registry.test.ts
@@ -1,39 +1,39 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { deployFullSuiteFixture } from "../fixtures/deploy-full-suite.fixture";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { deployFullSuiteFixture } from '../fixtures/deploy-full-suite.fixture';
 
-describe("ClaimTopicsRegistry", () => {
-  describe(".init", () => {
-    describe("when contract was already initialized", () => {
-      it("should revert", async () => {
+describe('ClaimTopicsRegistry', () => {
+  describe('.init', () => {
+    describe('when contract was already initialized', () => {
+      it('should revert', async () => {
         const {
           suite: { claimTopicsRegistry },
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(claimTopicsRegistry.init()).to.be.revertedWith(
-          "Initializable: contract is already initialized"
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe(".addClaimTopic", () => {
-    describe("when sender is not owner", () => {
-      it("should revert", async () => {
+  describe('.addClaimTopic', () => {
+    describe('when sender is not owner', () => {
+      it('should revert', async () => {
         const {
           suite: { claimTopicsRegistry },
           accounts: { anotherWallet },
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(
-          claimTopicsRegistry.connect(anotherWallet).addClaimTopic(1)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+          claimTopicsRegistry.connect(anotherWallet).addClaimTopic(1),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is owner", () => {
-      describe("when topic array contains more than 14 elements", () => {
-        it("should revert", async () => {
+    describe('when sender is owner', () => {
+      describe('when topic array contains more than 14 elements', () => {
+        it('should revert', async () => {
           const {
             suite: { claimTopicsRegistry },
             accounts: { deployer },
@@ -41,18 +41,18 @@ describe("ClaimTopicsRegistry", () => {
 
           await Promise.all(
             Array.from({ length: 14 }, (_, i) => i).map((i) =>
-              claimTopicsRegistry.addClaimTopic(i)
-            )
+              claimTopicsRegistry.addClaimTopic(i),
+            ),
           );
 
           await expect(
-            claimTopicsRegistry.connect(deployer).addClaimTopic(14)
-          ).to.be.revertedWith("cannot require more than 15 topics");
+            claimTopicsRegistry.connect(deployer).addClaimTopic(14),
+          ).to.be.revertedWith('cannot require more than 15 topics');
         });
       });
 
-      describe("when adding a topic that is already added", () => {
-        it("should revert", async () => {
+      describe('when adding a topic that is already added', () => {
+        it('should revert', async () => {
           const {
             suite: { claimTopicsRegistry },
             accounts: { deployer },
@@ -61,29 +61,29 @@ describe("ClaimTopicsRegistry", () => {
           await claimTopicsRegistry.addClaimTopic(1);
 
           await expect(
-            claimTopicsRegistry.connect(deployer).addClaimTopic(1)
-          ).to.be.revertedWith("claimTopic already exists");
+            claimTopicsRegistry.connect(deployer).addClaimTopic(1),
+          ).to.be.revertedWith('claimTopic already exists');
         });
       });
     });
   });
 
-  describe(".removeClaimTopic", () => {
-    describe("when sender is not owner", () => {
-      it("should revert", async () => {
+  describe('.removeClaimTopic', () => {
+    describe('when sender is not owner', () => {
+      it('should revert', async () => {
         const {
           suite: { claimTopicsRegistry },
           accounts: { anotherWallet },
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(
-          claimTopicsRegistry.connect(anotherWallet).removeClaimTopic(1)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+          claimTopicsRegistry.connect(anotherWallet).removeClaimTopic(1),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is owner", () => {
-      it("should remove claim topic", async () => {
+    describe('when sender is owner', () => {
+      it('should remove claim topic', async () => {
         const {
           suite: { claimTopicsRegistry },
           accounts: { deployer },
@@ -97,7 +97,7 @@ describe("ClaimTopicsRegistry", () => {
           .connect(deployer)
           .removeClaimTopic(2);
         await expect(tx)
-          .to.emit(claimTopicsRegistry, "ClaimTopicRemoved")
+          .to.emit(claimTopicsRegistry, 'ClaimTopicRemoved')
           .withArgs(2);
       });
     });

--- a/test/registries/identity-registry-storage.test.ts
+++ b/test/registries/identity-registry-storage.test.ts
@@ -1,26 +1,26 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { deployFullSuiteFixture } from "../fixtures/deploy-full-suite.fixture";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { deployFullSuiteFixture } from '../fixtures/deploy-full-suite.fixture';
 
-describe("IdentityRegistryStorage", () => {
-  describe(".init", () => {
-    describe("when contract was already initialized", () => {
-      it("should revert", async () => {
+describe('IdentityRegistryStorage', () => {
+  describe('.init', () => {
+    describe('when contract was already initialized', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistryStorage },
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(identityRegistryStorage.init()).to.be.revertedWith(
-          "Initializable: contract is already initialized"
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe(".addIdentityToStorage()", () => {
-    describe("when sender is not agent", () => {
-      it("should revert", async () => {
+  describe('.addIdentityToStorage()', () => {
+    describe('when sender is not agent', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistryStorage },
           accounts: { anotherWallet, charlieWallet },
@@ -33,15 +33,15 @@ describe("IdentityRegistryStorage", () => {
             .addIdentityToStorage(
               charlieWallet.address,
               charlieIdentity.address,
-              42
-            )
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+              42,
+            ),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when sender is agent", () => {
-      describe("when identity is zero address", () => {
-        it("should revert", async () => {
+    describe('when sender is agent', () => {
+      describe('when identity is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent, charlieWallet },
@@ -55,14 +55,14 @@ describe("IdentityRegistryStorage", () => {
               .addIdentityToStorage(
                 charlieWallet.address,
                 ethers.constants.AddressZero,
-                42
-              )
-          ).to.be.revertedWith("invalid argument - zero address");
+                42,
+              ),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when wallet is zero address", () => {
-        it("should revert", async () => {
+      describe('when wallet is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent },
@@ -77,14 +77,14 @@ describe("IdentityRegistryStorage", () => {
               .addIdentityToStorage(
                 ethers.constants.AddressZero,
                 charlieIdentity.address,
-                42
-              )
-          ).to.be.revertedWith("invalid argument - zero address");
+                42,
+              ),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when wallet is already registered", () => {
-        it("should revert", async () => {
+      describe('when wallet is already registered', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent, bobWallet },
@@ -99,17 +99,17 @@ describe("IdentityRegistryStorage", () => {
               .addIdentityToStorage(
                 bobWallet.address,
                 charlieIdentity.address,
-                42
-              )
-          ).to.be.revertedWith("address stored already");
+                42,
+              ),
+          ).to.be.revertedWith('address stored already');
         });
       });
     });
   });
 
-  describe(".modifyStoredIdentity()", () => {
-    describe("when sender is not agent", () => {
-      it("should revert", async () => {
+  describe('.modifyStoredIdentity()', () => {
+    describe('when sender is not agent', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistryStorage },
           accounts: { anotherWallet, charlieWallet },
@@ -121,15 +121,15 @@ describe("IdentityRegistryStorage", () => {
             .connect(anotherWallet)
             .modifyStoredIdentity(
               charlieWallet.address,
-              charlieIdentity.address
-            )
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+              charlieIdentity.address,
+            ),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when sender is agent", () => {
-      describe("when identity is zero address", () => {
-        it("should revert", async () => {
+    describe('when sender is agent', () => {
+      describe('when identity is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent, charlieWallet },
@@ -142,14 +142,14 @@ describe("IdentityRegistryStorage", () => {
               .connect(tokenAgent)
               .modifyStoredIdentity(
                 charlieWallet.address,
-                ethers.constants.AddressZero
-              )
-          ).to.be.revertedWith("invalid argument - zero address");
+                ethers.constants.AddressZero,
+              ),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when wallet is zero address", () => {
-        it("should revert", async () => {
+      describe('when wallet is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent },
@@ -163,14 +163,14 @@ describe("IdentityRegistryStorage", () => {
               .connect(tokenAgent)
               .modifyStoredIdentity(
                 ethers.constants.AddressZero,
-                charlieIdentity.address
-              )
-          ).to.be.revertedWith("invalid argument - zero address");
+                charlieIdentity.address,
+              ),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when wallet is not registered", () => {
-        it("should revert", async () => {
+      describe('when wallet is not registered', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent, charlieWallet },
@@ -184,17 +184,17 @@ describe("IdentityRegistryStorage", () => {
               .connect(tokenAgent)
               .modifyStoredIdentity(
                 charlieWallet.address,
-                charlieIdentity.address
-              )
-          ).to.be.revertedWith("address not stored yet");
+                charlieIdentity.address,
+              ),
+          ).to.be.revertedWith('address not stored yet');
         });
       });
     });
   });
 
-  describe(".modifyStoredInvestorCountry()", () => {
-    describe("when sender is not agent", () => {
-      it("should revert", async () => {
+  describe('.modifyStoredInvestorCountry()', () => {
+    describe('when sender is not agent', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistryStorage },
           accounts: { anotherWallet, charlieWallet },
@@ -203,14 +203,14 @@ describe("IdentityRegistryStorage", () => {
         await expect(
           identityRegistryStorage
             .connect(anotherWallet)
-            .modifyStoredInvestorCountry(charlieWallet.address, 42)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+            .modifyStoredInvestorCountry(charlieWallet.address, 42),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when sender is agent", () => {
-      describe("when wallet is zero address", () => {
-        it("should revert", async () => {
+    describe('when sender is agent', () => {
+      describe('when wallet is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent },
@@ -221,13 +221,13 @@ describe("IdentityRegistryStorage", () => {
           await expect(
             identityRegistryStorage
               .connect(tokenAgent)
-              .modifyStoredInvestorCountry(ethers.constants.AddressZero, 42)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .modifyStoredInvestorCountry(ethers.constants.AddressZero, 42),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when wallet is not registered", () => {
-        it("should revert", async () => {
+      describe('when wallet is not registered', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent, charlieWallet },
@@ -238,16 +238,16 @@ describe("IdentityRegistryStorage", () => {
           await expect(
             identityRegistryStorage
               .connect(tokenAgent)
-              .modifyStoredInvestorCountry(charlieWallet.address, 42)
-          ).to.be.revertedWith("address not stored yet");
+              .modifyStoredInvestorCountry(charlieWallet.address, 42),
+          ).to.be.revertedWith('address not stored yet');
         });
       });
     });
   });
 
-  describe(".removeIdentityFromStorage()", () => {
-    describe("when sender is not agent", () => {
-      it("should revert", async () => {
+  describe('.removeIdentityFromStorage()', () => {
+    describe('when sender is not agent', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistryStorage },
           accounts: { anotherWallet, charlieWallet },
@@ -256,14 +256,14 @@ describe("IdentityRegistryStorage", () => {
         await expect(
           identityRegistryStorage
             .connect(anotherWallet)
-            .removeIdentityFromStorage(charlieWallet.address)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+            .removeIdentityFromStorage(charlieWallet.address),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when sender is agent", () => {
-      describe("when wallet is zero address", () => {
-        it("should revert", async () => {
+    describe('when sender is agent', () => {
+      describe('when wallet is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent },
@@ -274,13 +274,13 @@ describe("IdentityRegistryStorage", () => {
           await expect(
             identityRegistryStorage
               .connect(tokenAgent)
-              .removeIdentityFromStorage(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .removeIdentityFromStorage(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when wallet is not registered", () => {
-        it("should revert", async () => {
+      describe('when wallet is not registered', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { tokenAgent, charlieWallet },
@@ -291,16 +291,16 @@ describe("IdentityRegistryStorage", () => {
           await expect(
             identityRegistryStorage
               .connect(tokenAgent)
-              .removeIdentityFromStorage(charlieWallet.address)
-          ).to.be.revertedWith("address not stored yet");
+              .removeIdentityFromStorage(charlieWallet.address),
+          ).to.be.revertedWith('address not stored yet');
         });
       });
     });
   });
 
-  describe(".bindIdentityRegistry()", () => {
-    describe("when sender is not owner", () => {
-      it("should revert", async () => {
+  describe('.bindIdentityRegistry()', () => {
+    describe('when sender is not owner', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistryStorage },
           accounts: { anotherWallet },
@@ -310,14 +310,14 @@ describe("IdentityRegistryStorage", () => {
         await expect(
           identityRegistryStorage
             .connect(anotherWallet)
-            .bindIdentityRegistry(charlieIdentity.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .bindIdentityRegistry(charlieIdentity.address),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is owner", () => {
-      describe("when identity registries is zero address", () => {
-        it("should revert", async () => {
+    describe('when sender is owner', () => {
+      describe('when identity registries is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { deployer },
@@ -326,13 +326,13 @@ describe("IdentityRegistryStorage", () => {
           await expect(
             identityRegistryStorage
               .connect(deployer)
-              .bindIdentityRegistry(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .bindIdentityRegistry(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when there are already 299 identity registries bound", () => {
-        it("should revert", async () => {
+      describe('when there are already 299 identity registries bound', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { deployer },
@@ -343,23 +343,23 @@ describe("IdentityRegistryStorage", () => {
             Array.from({ length: 299 }, () =>
               identityRegistryStorage
                 .connect(deployer)
-                .bindIdentityRegistry(ethers.Wallet.createRandom().address)
-            )
+                .bindIdentityRegistry(ethers.Wallet.createRandom().address),
+            ),
           );
 
           await expect(
             identityRegistryStorage
               .connect(deployer)
-              .bindIdentityRegistry(charlieIdentity.address)
-          ).to.be.revertedWith("cannot bind more than 300 IR to 1 IRS");
+              .bindIdentityRegistry(charlieIdentity.address),
+          ).to.be.revertedWith('cannot bind more than 300 IR to 1 IRS');
         });
       });
     });
   });
 
-  describe(".unbindIdentityRegistry()", () => {
-    describe("when sender is not agent", () => {
-      it("should revert", async () => {
+  describe('.unbindIdentityRegistry()', () => {
+    describe('when sender is not agent', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistryStorage },
           accounts: { anotherWallet },
@@ -369,14 +369,14 @@ describe("IdentityRegistryStorage", () => {
         await expect(
           identityRegistryStorage
             .connect(anotherWallet)
-            .unbindIdentityRegistry(charlieIdentity.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .unbindIdentityRegistry(charlieIdentity.address),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is agent", () => {
-      describe("when identity registries is zero address", () => {
-        it("should revert", async () => {
+    describe('when sender is agent', () => {
+      describe('when identity registries is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage },
             accounts: { deployer },
@@ -385,32 +385,32 @@ describe("IdentityRegistryStorage", () => {
           await expect(
             identityRegistryStorage
               .connect(deployer)
-              .unbindIdentityRegistry(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .unbindIdentityRegistry(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when identity registries not bound", () => {
-        it("should revert", async () => {
+      describe('when identity registries not bound', () => {
+        it('should revert', async () => {
           const {
             suite: { identityRegistryStorage, identityRegistry },
             accounts: { deployer },
           } = await loadFixture(deployFullSuiteFixture);
 
           await identityRegistryStorage.unbindIdentityRegistry(
-            identityRegistry.address
+            identityRegistry.address,
           );
 
           await expect(
             identityRegistryStorage
               .connect(deployer)
-              .unbindIdentityRegistry(identityRegistry.address)
-          ).to.be.revertedWith("identity registry is not stored");
+              .unbindIdentityRegistry(identityRegistry.address),
+          ).to.be.revertedWith('identity registry is not stored');
         });
       });
 
-      describe("when identity registries is bound", () => {
-        it("should unbind the identity registry", async () => {
+      describe('when identity registries is bound', () => {
+        it('should unbind the identity registry', async () => {
           const {
             suite: { identityRegistryStorage, identityRegistry },
             accounts: { deployer },
@@ -418,21 +418,21 @@ describe("IdentityRegistryStorage", () => {
           } = await loadFixture(deployFullSuiteFixture);
 
           await identityRegistryStorage.bindIdentityRegistry(
-            charlieIdentity.address
+            charlieIdentity.address,
           );
           await identityRegistryStorage.bindIdentityRegistry(
-            bobIdentity.address
+            bobIdentity.address,
           );
 
           const tx = await identityRegistryStorage
             .connect(deployer)
             .unbindIdentityRegistry(charlieIdentity.address);
           await expect(tx)
-            .to.emit(identityRegistryStorage, "IdentityRegistryUnbound")
+            .to.emit(identityRegistryStorage, 'IdentityRegistryUnbound')
             .withArgs(charlieIdentity.address);
 
           await expect(
-            identityRegistryStorage.linkedIdentityRegistries()
+            identityRegistryStorage.linkedIdentityRegistries(),
           ).to.eventually.be.deep.equal([
             identityRegistry.address,
             bobIdentity.address,

--- a/test/registries/identity-registry.test.ts
+++ b/test/registries/identity-registry.test.ts
@@ -1,11 +1,11 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { deployFullSuiteFixture } from "../fixtures/deploy-full-suite.fixture";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { deployFullSuiteFixture } from '../fixtures/deploy-full-suite.fixture';
 
-describe("IdentityRegistry", () => {
-  describe(".init()", () => {
-    it("should prevent re-initialization", async () => {
+describe('IdentityRegistry', () => {
+  describe('.init()', () => {
+    it('should prevent re-initialization', async () => {
       const {
         suite: { identityRegistry },
         accounts: { deployer },
@@ -17,39 +17,39 @@ describe("IdentityRegistry", () => {
           .init(
             ethers.constants.AddressZero,
             ethers.constants.AddressZero,
-            ethers.constants.AddressZero
-          )
-      ).to.be.revertedWith("Initializable: contract is already initialized");
+            ethers.constants.AddressZero,
+          ),
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
 
-    it("should reject zero address for Trustes Issuers Registry", async () => {
-      const identityRegistry = await ethers.deployContract("IdentityRegistry");
+    it('should reject zero address for Trustes Issuers Registry', async () => {
+      const identityRegistry = await ethers.deployContract('IdentityRegistry');
       const address = ethers.Wallet.createRandom().address;
       await expect(
-        identityRegistry.init(ethers.constants.AddressZero, address, address)
-      ).to.be.revertedWith("invalid argument - zero address");
+        identityRegistry.init(ethers.constants.AddressZero, address, address),
+      ).to.be.revertedWith('invalid argument - zero address');
     });
 
-    it("should reject zero address for Claim Topics Registry", async () => {
-      const identityRegistry = await ethers.deployContract("IdentityRegistry");
+    it('should reject zero address for Claim Topics Registry', async () => {
+      const identityRegistry = await ethers.deployContract('IdentityRegistry');
       const address = ethers.Wallet.createRandom().address;
       await expect(
-        identityRegistry.init(address, ethers.constants.AddressZero, address)
-      ).to.be.revertedWith("invalid argument - zero address");
+        identityRegistry.init(address, ethers.constants.AddressZero, address),
+      ).to.be.revertedWith('invalid argument - zero address');
     });
 
-    it("should reject zero address for Identity Storage", async () => {
-      const identityRegistry = await ethers.deployContract("IdentityRegistry");
+    it('should reject zero address for Identity Storage', async () => {
+      const identityRegistry = await ethers.deployContract('IdentityRegistry');
       const address = ethers.Wallet.createRandom().address;
       await expect(
-        identityRegistry.init(address, address, ethers.constants.AddressZero)
-      ).to.be.revertedWith("invalid argument - zero address");
+        identityRegistry.init(address, address, ethers.constants.AddressZero),
+      ).to.be.revertedWith('invalid argument - zero address');
     });
   });
 
-  describe(".updateIdentity()", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.updateIdentity()', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistry },
           accounts: { anotherWallet },
@@ -59,15 +59,15 @@ describe("IdentityRegistry", () => {
         await expect(
           identityRegistry
             .connect(anotherWallet)
-            .updateIdentity(bobIdentity.address, charlieIdentity.address)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+            .updateIdentity(bobIdentity.address, charlieIdentity.address),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
   });
 
-  describe(".updateCountry()", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.updateCountry()', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistry },
           accounts: { anotherWallet },
@@ -77,15 +77,15 @@ describe("IdentityRegistry", () => {
         await expect(
           identityRegistry
             .connect(anotherWallet)
-            .updateCountry(bobIdentity.address, 100)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+            .updateCountry(bobIdentity.address, 100),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
   });
 
-  describe(".deleteIdentity()", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.deleteIdentity()', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistry },
           accounts: { anotherWallet, bobWallet },
@@ -94,15 +94,15 @@ describe("IdentityRegistry", () => {
         await expect(
           identityRegistry
             .connect(anotherWallet)
-            .deleteIdentity(bobWallet.address)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+            .deleteIdentity(bobWallet.address),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
   });
 
-  describe(".registerIdentity()", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.registerIdentity()', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistry },
           accounts: { anotherWallet },
@@ -114,16 +114,16 @@ describe("IdentityRegistry", () => {
             .registerIdentity(
               ethers.constants.AddressZero,
               ethers.constants.AddressZero,
-              0
-            )
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+              0,
+            ),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
   });
 
-  describe(".setIdentityRegistryStorage()", () => {
-    describe("when sender is not the owner", () => {
-      it("should revert", async () => {
+  describe('.setIdentityRegistryStorage()', () => {
+    describe('when sender is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistry },
           accounts: { anotherWallet },
@@ -132,13 +132,13 @@ describe("IdentityRegistry", () => {
         await expect(
           identityRegistry
             .connect(anotherWallet)
-            .setIdentityRegistryStorage(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .setIdentityRegistryStorage(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is the owner", () => {
-      it("should set the identity registry storage", async () => {
+    describe('when sender is the owner', () => {
+      it('should set the identity registry storage', async () => {
         const {
           suite: { identityRegistry },
           accounts: { deployer },
@@ -148,18 +148,18 @@ describe("IdentityRegistry", () => {
           .connect(deployer)
           .setIdentityRegistryStorage(ethers.constants.AddressZero);
         await expect(tx)
-          .to.emit(identityRegistry, "IdentityStorageSet")
+          .to.emit(identityRegistry, 'IdentityStorageSet')
           .withArgs(ethers.constants.AddressZero);
         expect(await identityRegistry.identityStorage()).to.be.equal(
-          ethers.constants.AddressZero
+          ethers.constants.AddressZero,
         );
       });
     });
   });
 
-  describe(".setClaimTopicsRegistry()", () => {
-    describe("when sender is not the owner", () => {
-      it("should revert", async () => {
+  describe('.setClaimTopicsRegistry()', () => {
+    describe('when sender is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistry },
           accounts: { anotherWallet },
@@ -168,13 +168,13 @@ describe("IdentityRegistry", () => {
         await expect(
           identityRegistry
             .connect(anotherWallet)
-            .setClaimTopicsRegistry(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .setClaimTopicsRegistry(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is the owner", () => {
-      it("should set the claim topics registry", async () => {
+    describe('when sender is the owner', () => {
+      it('should set the claim topics registry', async () => {
         const {
           suite: { identityRegistry },
           accounts: { deployer },
@@ -184,18 +184,18 @@ describe("IdentityRegistry", () => {
           .connect(deployer)
           .setClaimTopicsRegistry(ethers.constants.AddressZero);
         await expect(tx)
-          .to.emit(identityRegistry, "ClaimTopicsRegistrySet")
+          .to.emit(identityRegistry, 'ClaimTopicsRegistrySet')
           .withArgs(ethers.constants.AddressZero);
         expect(await identityRegistry.topicsRegistry()).to.be.equal(
-          ethers.constants.AddressZero
+          ethers.constants.AddressZero,
         );
       });
     });
   });
 
-  describe(".setTrustedIssuersRegistry()", () => {
-    describe("when sender is not the owner", () => {
-      it("should revert", async () => {
+  describe('.setTrustedIssuersRegistry()', () => {
+    describe('when sender is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { identityRegistry },
           accounts: { anotherWallet },
@@ -204,13 +204,13 @@ describe("IdentityRegistry", () => {
         await expect(
           identityRegistry
             .connect(anotherWallet)
-            .setTrustedIssuersRegistry(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .setTrustedIssuersRegistry(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is the owner", () => {
-      it("should set the trusted issuers registry", async () => {
+    describe('when sender is the owner', () => {
+      it('should set the trusted issuers registry', async () => {
         const {
           suite: { identityRegistry },
           accounts: { deployer },
@@ -220,18 +220,18 @@ describe("IdentityRegistry", () => {
           .connect(deployer)
           .setTrustedIssuersRegistry(ethers.constants.AddressZero);
         await expect(tx)
-          .to.emit(identityRegistry, "TrustedIssuersRegistrySet")
+          .to.emit(identityRegistry, 'TrustedIssuersRegistrySet')
           .withArgs(ethers.constants.AddressZero);
         expect(await identityRegistry.issuersRegistry()).to.be.equal(
-          ethers.constants.AddressZero
+          ethers.constants.AddressZero,
         );
       });
     });
   });
 
-  describe(".isVerified()", () => {
-    describe("when there are no require claim topics", () => {
-      it("should return true when the identity is registered", async () => {
+  describe('.isVerified()', () => {
+    describe('when there are no require claim topics', () => {
+      it('should return true when the identity is registered', async () => {
         const {
           suite: { identityRegistry, claimTopicsRegistry },
           accounts: { tokenAgent, charlieWallet },
@@ -247,7 +247,7 @@ describe("IdentityRegistry", () => {
 
         const topics = await claimTopicsRegistry.getClaimTopics();
         await Promise.all(
-          topics.map((topic) => claimTopicsRegistry.removeClaimTopic(topic))
+          topics.map((topic) => claimTopicsRegistry.removeClaimTopic(topic)),
         );
 
         await expect(identityRegistry.isVerified(charlieWallet.address)).to
@@ -255,8 +255,8 @@ describe("IdentityRegistry", () => {
       });
     });
 
-    describe("when claim topics are required but there are not trusted issuers for them", () => {
-      it("should return false", async () => {
+    describe('when claim topics are required but there are not trusted issuers for them', () => {
+      it('should return false', async () => {
         const {
           suite: {
             identityRegistry,
@@ -272,12 +272,12 @@ describe("IdentityRegistry", () => {
         const topics = await claimTopicsRegistry.getClaimTopics();
         const trustedIssuers =
           await trustedIssuersRegistry.getTrustedIssuersForClaimTopic(
-            topics[0]
+            topics[0],
           );
         await Promise.all(
           trustedIssuers.map((issuer) =>
-            trustedIssuersRegistry.removeTrustedIssuer(issuer)
-          )
+            trustedIssuersRegistry.removeTrustedIssuer(issuer),
+          ),
         );
 
         await expect(identityRegistry.isVerified(aliceWallet.address)).to
@@ -285,8 +285,8 @@ describe("IdentityRegistry", () => {
       });
     });
 
-    describe("when the only claim required was revoked", () => {
-      it("should return false", async () => {
+    describe('when the only claim required was revoked', () => {
+      it('should return false', async () => {
         const {
           suite: { identityRegistry, claimTopicsRegistry, claimIssuerContract },
           accounts: { aliceWallet },
@@ -307,8 +307,8 @@ describe("IdentityRegistry", () => {
       });
     });
 
-    describe("when the claim issuer throws an error", () => {
-      it("should return true if there is another valid claim", async () => {
+    describe('when the claim issuer throws an error', () => {
+      it('should return true if there is another valid claim', async () => {
         const {
           suite: {
             identityRegistry,
@@ -321,19 +321,19 @@ describe("IdentityRegistry", () => {
         } = await loadFixture(deployFullSuiteFixture);
 
         const trickyClaimIssuer = await ethers.deployContract(
-          "ClaimIssuerTrick"
+          'ClaimIssuerTrick',
         );
         const claimTopics = await claimTopicsRegistry.getClaimTopics();
         await trustedIssuersRegistry.removeTrustedIssuer(
-          claimIssuerContract.address
+          claimIssuerContract.address,
         );
         await trustedIssuersRegistry.addTrustedIssuer(
           trickyClaimIssuer.address,
-          claimTopics
+          claimTopics,
         );
         await trustedIssuersRegistry.addTrustedIssuer(
           claimIssuerContract.address,
-          claimTopics
+          claimTopics,
         );
         const claimIds = await aliceIdentity.getClaimIdsByTopic(claimTopics[0]);
         const claim = await aliceIdentity.getClaim(claimIds[0]);
@@ -344,9 +344,9 @@ describe("IdentityRegistry", () => {
             claimTopics[0],
             1,
             trickyClaimIssuer.address,
-            "0x00",
-            "0x00",
-            ""
+            '0x00',
+            '0x00',
+            '',
           );
         await aliceIdentity
           .connect(aliceWallet)
@@ -356,14 +356,14 @@ describe("IdentityRegistry", () => {
             claim.issuer,
             claim.signature,
             claim.data,
-            claim.uri
+            claim.uri,
           );
 
         await expect(identityRegistry.isVerified(aliceWallet.address)).to
           .eventually.be.true;
       });
 
-      it("should return false if there are no other valid claim", async () => {
+      it('should return false if there are no other valid claim', async () => {
         const {
           suite: {
             identityRegistry,
@@ -375,12 +375,12 @@ describe("IdentityRegistry", () => {
         } = await loadFixture(deployFullSuiteFixture);
 
         const trickyClaimIssuer = await ethers.deployContract(
-          "ClaimIssuerTrick"
+          'ClaimIssuerTrick',
         );
         const claimTopics = await claimTopicsRegistry.getClaimTopics();
         await trustedIssuersRegistry.addTrustedIssuer(
           trickyClaimIssuer.address,
-          claimTopics
+          claimTopics,
         );
         const claimIds = await aliceIdentity.getClaimIdsByTopic(claimTopics[0]);
         await aliceIdentity.connect(aliceWallet).removeClaim(claimIds[0]);
@@ -390,9 +390,9 @@ describe("IdentityRegistry", () => {
             claimTopics[0],
             1,
             trickyClaimIssuer.address,
-            "0x00",
-            "0x00",
-            ""
+            '0x00',
+            '0x00',
+            '',
           );
 
         await expect(identityRegistry.isVerified(aliceWallet.address)).to

--- a/test/registries/trusted-issuers-registry.test.ts
+++ b/test/registries/trusted-issuers-registry.test.ts
@@ -1,12 +1,12 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { deployFullSuiteFixture } from "../fixtures/deploy-full-suite.fixture";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { deployFullSuiteFixture } from '../fixtures/deploy-full-suite.fixture';
 
-describe("TrustedIssuersRegistry", () => {
-  describe(".addTrustedIssuer()", () => {
-    describe("when sender is not the owner", () => {
-      it("should revert", async () => {
+describe('TrustedIssuersRegistry', () => {
+  describe('.addTrustedIssuer()', () => {
+    describe('when sender is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { trustedIssuersRegistry },
           accounts: { anotherWallet },
@@ -15,14 +15,14 @@ describe("TrustedIssuersRegistry", () => {
         await expect(
           trustedIssuersRegistry
             .connect(anotherWallet)
-            .addTrustedIssuer(anotherWallet.address, [10])
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .addTrustedIssuer(anotherWallet.address, [10]),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is the owner", () => {
-      describe("when issuer to add is zero address", () => {
-        it("should revert", async () => {
+    describe('when sender is the owner', () => {
+      describe('when issuer to add is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry },
             accounts: { deployer },
@@ -31,13 +31,13 @@ describe("TrustedIssuersRegistry", () => {
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .addTrustedIssuer(ethers.constants.AddressZero, [10])
-          ).to.be.revertedWith("invalid argument - zero address");
+              .addTrustedIssuer(ethers.constants.AddressZero, [10]),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when issuer is already registered", () => {
-        it("should revert", async () => {
+      describe('when issuer is already registered', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry, claimIssuerContract },
             accounts: { deployer },
@@ -45,19 +45,19 @@ describe("TrustedIssuersRegistry", () => {
 
           const claimTopics =
             await trustedIssuersRegistry.getTrustedIssuerClaimTopics(
-              claimIssuerContract.address
+              claimIssuerContract.address,
             );
 
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .addTrustedIssuer(claimIssuerContract.address, claimTopics)
-          ).to.be.revertedWith("trusted Issuer already exists");
+              .addTrustedIssuer(claimIssuerContract.address, claimTopics),
+          ).to.be.revertedWith('trusted Issuer already exists');
         });
       });
 
-      describe("when claim topics array is empty", () => {
-        it("should revert", async () => {
+      describe('when claim topics array is empty', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry },
             accounts: { deployer },
@@ -66,13 +66,13 @@ describe("TrustedIssuersRegistry", () => {
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .addTrustedIssuer(deployer.address, [])
-          ).to.be.revertedWith("trusted claim topics cannot be empty");
+              .addTrustedIssuer(deployer.address, []),
+          ).to.be.revertedWith('trusted claim topics cannot be empty');
         });
       });
 
-      describe("when claim topics array exceeds 15 topics", () => {
-        it("should revert", async () => {
+      describe('when claim topics array exceeds 15 topics', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry },
             accounts: { deployer },
@@ -83,13 +83,13 @@ describe("TrustedIssuersRegistry", () => {
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .addTrustedIssuer(deployer.address, claimTopics)
-          ).to.be.revertedWith("cannot have more than 15 claim topics");
+              .addTrustedIssuer(deployer.address, claimTopics),
+          ).to.be.revertedWith('cannot have more than 15 claim topics');
         });
       });
 
-      describe("when there are already 49 trusted issuers", () => {
-        it("should revert", async () => {
+      describe('when there are already 49 trusted issuers', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry },
             accounts: { deployer },
@@ -103,22 +103,22 @@ describe("TrustedIssuersRegistry", () => {
               return trustedIssuersRegistry
                 .connect(deployer)
                 .addTrustedIssuer(wallet.address, claimTopics);
-            })
+            }),
           );
 
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .addTrustedIssuer(deployer.address, claimTopics)
-          ).to.be.revertedWith("cannot have more than 50 trusted issuers");
+              .addTrustedIssuer(deployer.address, claimTopics),
+          ).to.be.revertedWith('cannot have more than 50 trusted issuers');
         });
       });
     });
   });
 
-  describe(".removeTrustedIssuer()", () => {
-    describe("when sender is not the owner", () => {
-      it("should revert", async () => {
+  describe('.removeTrustedIssuer()', () => {
+    describe('when sender is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { trustedIssuersRegistry },
           accounts: { anotherWallet },
@@ -127,14 +127,14 @@ describe("TrustedIssuersRegistry", () => {
         await expect(
           trustedIssuersRegistry
             .connect(anotherWallet)
-            .removeTrustedIssuer(anotherWallet.address)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .removeTrustedIssuer(anotherWallet.address),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is the owner", () => {
-      describe("when issuer to remove is zero address", () => {
-        it("should revert", async () => {
+    describe('when sender is the owner', () => {
+      describe('when issuer to remove is zero address', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry },
             accounts: { deployer },
@@ -143,13 +143,13 @@ describe("TrustedIssuersRegistry", () => {
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .removeTrustedIssuer(ethers.constants.AddressZero)
-          ).to.be.revertedWith("invalid argument - zero address");
+              .removeTrustedIssuer(ethers.constants.AddressZero),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when issuer is not registered", () => {
-        it("should revert", async () => {
+      describe('when issuer is not registered', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry },
             accounts: { deployer },
@@ -158,13 +158,13 @@ describe("TrustedIssuersRegistry", () => {
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .removeTrustedIssuer(deployer.address)
-          ).to.be.revertedWith("NOT a trusted issuer");
+              .removeTrustedIssuer(deployer.address),
+          ).to.be.revertedWith('NOT a trusted issuer');
         });
       });
 
-      describe("when issuer is registered", () => {
-        it("should remove the issuer from trusted list", async () => {
+      describe('when issuer is registered', () => {
+        it('should remove the issuer from trusted list', async () => {
           const {
             suite: { trustedIssuersRegistry, claimIssuerContract },
             accounts: { deployer, anotherWallet, charlieWallet, bobWallet },
@@ -172,33 +172,33 @@ describe("TrustedIssuersRegistry", () => {
 
           await trustedIssuersRegistry.addTrustedIssuer(
             bobWallet.address,
-            [66, 100, 10]
+            [66, 100, 10],
           );
           await trustedIssuersRegistry.addTrustedIssuer(
             anotherWallet.address,
-            [10, 42]
+            [10, 42],
           );
           await trustedIssuersRegistry.addTrustedIssuer(
             charlieWallet.address,
-            [42, 66, 10]
+            [42, 66, 10],
           );
 
           await expect(
-            trustedIssuersRegistry.isTrustedIssuer(anotherWallet.address)
+            trustedIssuersRegistry.isTrustedIssuer(anotherWallet.address),
           ).to.eventually.be.true;
 
           const tx = await trustedIssuersRegistry
             .connect(deployer)
             .removeTrustedIssuer(anotherWallet.address);
           await expect(tx)
-            .to.emit(trustedIssuersRegistry, "TrustedIssuerRemoved")
+            .to.emit(trustedIssuersRegistry, 'TrustedIssuerRemoved')
             .withArgs(anotherWallet.address);
 
           await expect(
-            trustedIssuersRegistry.isTrustedIssuer(anotherWallet.address)
+            trustedIssuersRegistry.isTrustedIssuer(anotherWallet.address),
           ).to.eventually.be.false;
           await expect(
-            trustedIssuersRegistry.getTrustedIssuers()
+            trustedIssuersRegistry.getTrustedIssuers(),
           ).to.eventually.deep.eq([
             claimIssuerContract.address,
             bobWallet.address,
@@ -209,9 +209,9 @@ describe("TrustedIssuersRegistry", () => {
     });
   });
 
-  describe(".updateIssuerClaimTopics()", () => {
-    describe("when sender is not the owner", () => {
-      it("should revert", async () => {
+  describe('.updateIssuerClaimTopics()', () => {
+    describe('when sender is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { trustedIssuersRegistry },
           accounts: { anotherWallet },
@@ -220,14 +220,14 @@ describe("TrustedIssuersRegistry", () => {
         await expect(
           trustedIssuersRegistry
             .connect(anotherWallet)
-            .updateIssuerClaimTopics(anotherWallet.address, [10])
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .updateIssuerClaimTopics(anotherWallet.address, [10]),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when sender is the owner", () => {
-      describe("when issuer to update is zero address", () => {
-        it("should rever", async () => {
+    describe('when sender is the owner', () => {
+      describe('when issuer to update is zero address', () => {
+        it('should rever', async () => {
           const {
             suite: { trustedIssuersRegistry },
             accounts: { deployer },
@@ -236,13 +236,13 @@ describe("TrustedIssuersRegistry", () => {
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .updateIssuerClaimTopics(ethers.constants.AddressZero, [10])
-          ).to.be.revertedWith("invalid argument - zero address");
+              .updateIssuerClaimTopics(ethers.constants.AddressZero, [10]),
+          ).to.be.revertedWith('invalid argument - zero address');
         });
       });
 
-      describe("when issuer is not registered", () => {
-        it("should revert", async () => {
+      describe('when issuer is not registered', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry },
             accounts: { deployer },
@@ -251,13 +251,13 @@ describe("TrustedIssuersRegistry", () => {
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .updateIssuerClaimTopics(deployer.address, [10])
-          ).to.be.revertedWith("NOT a trusted issuer");
+              .updateIssuerClaimTopics(deployer.address, [10]),
+          ).to.be.revertedWith('NOT a trusted issuer');
         });
       });
 
-      describe("when claim topics array have more that 15 elements", () => {
-        it("should revert", async () => {
+      describe('when claim topics array have more that 15 elements', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry, claimIssuerContract },
             accounts: { deployer },
@@ -268,13 +268,16 @@ describe("TrustedIssuersRegistry", () => {
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .updateIssuerClaimTopics(claimIssuerContract.address, claimTopics)
-          ).to.be.revertedWith("cannot have more than 15 claim topics");
+              .updateIssuerClaimTopics(
+                claimIssuerContract.address,
+                claimTopics,
+              ),
+          ).to.be.revertedWith('cannot have more than 15 claim topics');
         });
       });
 
-      describe("when claim topics array is empty", () => {
-        it("should revert", async () => {
+      describe('when claim topics array is empty', () => {
+        it('should revert', async () => {
           const {
             suite: { trustedIssuersRegistry, claimIssuerContract },
             accounts: { deployer },
@@ -283,13 +286,13 @@ describe("TrustedIssuersRegistry", () => {
           await expect(
             trustedIssuersRegistry
               .connect(deployer)
-              .updateIssuerClaimTopics(claimIssuerContract.address, [])
-          ).to.be.revertedWith("claim topics cannot be empty");
+              .updateIssuerClaimTopics(claimIssuerContract.address, []),
+          ).to.be.revertedWith('claim topics cannot be empty');
         });
       });
 
-      describe("when issuer is registered", () => {
-        it("should update the topics of the trusted issuers", async () => {
+      describe('when issuer is registered', () => {
+        it('should update the topics of the trusted issuers', async () => {
           const {
             suite: { trustedIssuersRegistry, claimIssuerContract },
             accounts: { deployer },
@@ -297,47 +300,47 @@ describe("TrustedIssuersRegistry", () => {
 
           const claimTopics =
             await trustedIssuersRegistry.getTrustedIssuerClaimTopics(
-              claimIssuerContract.address
+              claimIssuerContract.address,
             );
 
           const tx = await trustedIssuersRegistry
             .connect(deployer)
             .updateIssuerClaimTopics(claimIssuerContract.address, [66, 100]);
           await expect(tx)
-            .to.emit(trustedIssuersRegistry, "ClaimTopicsUpdated")
+            .to.emit(trustedIssuersRegistry, 'ClaimTopicsUpdated')
             .withArgs(claimIssuerContract.address, [66, 100]);
 
           await expect(
             trustedIssuersRegistry.hasClaimTopic(
               claimIssuerContract.address,
-              66
-            )
+              66,
+            ),
           ).to.eventually.be.true;
           await expect(
             trustedIssuersRegistry.hasClaimTopic(
               claimIssuerContract.address,
-              100
-            )
+              100,
+            ),
           ).to.eventually.be.true;
           await expect(
             trustedIssuersRegistry.hasClaimTopic(
               claimIssuerContract.address,
-              claimTopics[0]
-            )
+              claimTopics[0],
+            ),
           ).to.eventually.be.false;
           await expect(
             trustedIssuersRegistry.getTrustedIssuerClaimTopics(
-              claimIssuerContract.address
-            )
+              claimIssuerContract.address,
+            ),
           ).to.eventually.deep.eq([66, 100]);
         });
       });
     });
   });
 
-  describe(".getTrustedIssuerClaimTopics()", () => {
-    describe("when issuer is not registered", () => {
-      it("should revert", async () => {
+  describe('.getTrustedIssuerClaimTopics()', () => {
+    describe('when issuer is not registered', () => {
+      it('should revert', async () => {
         const {
           suite: { trustedIssuersRegistry },
           accounts: { deployer },
@@ -346,7 +349,7 @@ describe("TrustedIssuersRegistry", () => {
         await expect(
           trustedIssuersRegistry
             .connect(deployer)
-            .getTrustedIssuerClaimTopics(deployer.address)
+            .getTrustedIssuerClaimTopics(deployer.address),
         ).to.be.revertedWith("trusted Issuer doesn't exist");
       });
     });

--- a/test/token/token-information.test.ts
+++ b/test/token/token-information.test.ts
@@ -1,103 +1,103 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 import {
   deployFullSuiteFixture,
   deploySuiteWithModularCompliancesFixture,
-} from "../fixtures/deploy-full-suite.fixture";
+} from '../fixtures/deploy-full-suite.fixture';
 
-describe("Token - Information", () => {
-  describe(".setName()", () => {
-    describe("when the caller is not the owner", () => {
-      it("should revert", async () => {
+describe('Token - Information', () => {
+  describe('.setName()', () => {
+    describe('when the caller is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
         } = await loadFixture(deployFullSuiteFixture);
         await expect(
-          token.connect(anotherWallet).setName("My Token")
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+          token.connect(anotherWallet).setName('My Token'),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when the caller is the owner", () => {
-      describe("when the name is empty", () => {
-        it("should revert", async () => {
+    describe('when the caller is the owner', () => {
+      describe('when the name is empty', () => {
+        it('should revert', async () => {
           const {
             suite: { token },
           } = await loadFixture(deployFullSuiteFixture);
-          await expect(token.setName("")).to.be.revertedWith(
-            "invalid argument - empty string"
+          await expect(token.setName('')).to.be.revertedWith(
+            'invalid argument - empty string',
           );
         });
       });
 
-      it("should set the name", async () => {
+      it('should set the name', async () => {
         const {
           suite: { token },
         } = await loadFixture(deployFullSuiteFixture);
-        const tx = await token.setName("Updated Test Token");
+        const tx = await token.setName('Updated Test Token');
         await expect(tx)
-          .to.emit(token, "UpdatedTokenInformation")
+          .to.emit(token, 'UpdatedTokenInformation')
           .withArgs(
-            "Updated Test Token",
+            'Updated Test Token',
             await token.symbol(),
             await token.decimals(),
             await token.version(),
-            await token.onchainID()
+            await token.onchainID(),
           );
-        expect(await token.name()).to.equal("Updated Test Token");
+        expect(await token.name()).to.equal('Updated Test Token');
       });
     });
   });
 
-  describe(".setSymbol()", () => {
-    describe("when the caller is not the owner", () => {
-      it("should revert", async () => {
+  describe('.setSymbol()', () => {
+    describe('when the caller is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
         } = await loadFixture(deployFullSuiteFixture);
         await expect(
-          token.connect(anotherWallet).setSymbol("UpdtTK")
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+          token.connect(anotherWallet).setSymbol('UpdtTK'),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when the caller is the owner", () => {
-      describe("when the symbol is empty", () => {
-        it("should revert", async () => {
+    describe('when the caller is the owner', () => {
+      describe('when the symbol is empty', () => {
+        it('should revert', async () => {
           const {
             suite: { token },
           } = await loadFixture(deployFullSuiteFixture);
-          await expect(token.setSymbol("")).to.be.revertedWith(
-            "invalid argument - empty string"
+          await expect(token.setSymbol('')).to.be.revertedWith(
+            'invalid argument - empty string',
           );
         });
       });
 
-      it("should set the symbol", async () => {
+      it('should set the symbol', async () => {
         const {
           suite: { token },
         } = await loadFixture(deployFullSuiteFixture);
-        const tx = await token.setSymbol("UpdtTK");
+        const tx = await token.setSymbol('UpdtTK');
         await expect(tx)
-          .to.emit(token, "UpdatedTokenInformation")
+          .to.emit(token, 'UpdatedTokenInformation')
           .withArgs(
             await token.name(),
-            "UpdtTK",
+            'UpdtTK',
             await token.decimals(),
             await token.version(),
-            await token.onchainID()
+            await token.onchainID(),
           );
-        expect(await token.symbol()).to.equal("UpdtTK");
+        expect(await token.symbol()).to.equal('UpdtTK');
       });
     });
   });
 
-  describe(".setOnchainID()", () => {
-    describe("when the caller is not the owner", () => {
-      it("should revert", async () => {
+  describe('.setOnchainID()', () => {
+    describe('when the caller is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
@@ -105,34 +105,34 @@ describe("Token - Information", () => {
         await expect(
           token
             .connect(anotherWallet)
-            .setOnchainID(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .setOnchainID(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when the caller is the owner", () => {
-      it("should set the onchainID", async () => {
+    describe('when the caller is the owner', () => {
+      it('should set the onchainID', async () => {
         const {
           suite: { token },
         } = await loadFixture(deployFullSuiteFixture);
         const tx = await token.setOnchainID(ethers.constants.AddressZero);
         await expect(tx)
-          .to.emit(token, "UpdatedTokenInformation")
+          .to.emit(token, 'UpdatedTokenInformation')
           .withArgs(
             await token.name(),
             await token.symbol(),
             await token.decimals(),
             await token.version(),
-            ethers.constants.AddressZero
+            ethers.constants.AddressZero,
           );
         expect(await token.onchainID()).to.equal(ethers.constants.AddressZero);
       });
     });
   });
 
-  describe(".setIdentityRegistry()", () => {
-    describe("when the caller is not the owner", () => {
-      it("should revert", async () => {
+  describe('.setIdentityRegistry()', () => {
+    describe('when the caller is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
@@ -140,14 +140,14 @@ describe("Token - Information", () => {
         await expect(
           token
             .connect(anotherWallet)
-            .setIdentityRegistry(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .setIdentityRegistry(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
   });
 
-  describe(".totalSupply()", () => {
-    it("should return the total supply", async () => {
+  describe('.totalSupply()', () => {
+    it('should return the total supply', async () => {
       const {
         suite: { token },
         accounts: { aliceWallet, bobWallet },
@@ -160,9 +160,9 @@ describe("Token - Information", () => {
     });
   });
 
-  describe(".setCompliance", () => {
-    describe("when the caller is not the owner", () => {
-      it("should revert", async () => {
+  describe('.setCompliance', () => {
+    describe('when the caller is not the owner', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
@@ -170,14 +170,14 @@ describe("Token - Information", () => {
         await expect(
           token
             .connect(anotherWallet)
-            .setCompliance(ethers.constants.AddressZero)
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+            .setCompliance(ethers.constants.AddressZero),
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
   });
 
-  describe(".compliance()", () => {
-    it("should return the compliance address", async () => {
+  describe('.compliance()', () => {
+    it('should return the compliance address', async () => {
       const {
         suite: { token, compliance },
       } = await loadFixture(deploySuiteWithModularCompliancesFixture);
@@ -186,65 +186,65 @@ describe("Token - Information", () => {
     });
   });
 
-  describe(".pause()", () => {
-    describe("when the caller is not an agent", () => {
-      it("should revert", async () => {
+  describe('.pause()', () => {
+    describe('when the caller is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
         } = await loadFixture(deployFullSuiteFixture);
         await expect(token.connect(anotherWallet).pause()).to.be.revertedWith(
-          "AgentRole: caller does not have the Agent role"
+          'AgentRole: caller does not have the Agent role',
         );
       });
     });
 
-    describe("when the caller is an agent", () => {
-      describe("when the token is not paused", () => {
-        it("should pause the token", async () => {
+    describe('when the caller is an agent', () => {
+      describe('when the token is not paused', () => {
+        it('should pause the token', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent },
           } = await loadFixture(deployFullSuiteFixture);
           const tx = await token.connect(tokenAgent).pause();
           await expect(tx)
-            .to.emit(token, "Paused")
+            .to.emit(token, 'Paused')
             .withArgs(tokenAgent.address);
           expect(await token.paused()).to.be.true;
         });
       });
 
-      describe("when the token is paused", () => {
-        it("should revert", async () => {
+      describe('when the token is paused', () => {
+        it('should revert', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent },
           } = await loadFixture(deployFullSuiteFixture);
           await token.connect(tokenAgent).pause();
           await expect(token.connect(tokenAgent).pause()).to.be.revertedWith(
-            "Pausable: paused"
+            'Pausable: paused',
           );
         });
       });
     });
   });
 
-  describe(".unpause()", () => {
-    describe("when the caller is not an agent", () => {
-      it("should revert", async () => {
+  describe('.unpause()', () => {
+    describe('when the caller is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
         } = await loadFixture(deployFullSuiteFixture);
         await expect(token.connect(anotherWallet).unpause()).to.be.revertedWith(
-          "AgentRole: caller does not have the Agent role"
+          'AgentRole: caller does not have the Agent role',
         );
       });
     });
 
-    describe("when the caller is an agent", () => {
-      describe("when the token is paused", () => {
-        it("should unpause the token", async () => {
+    describe('when the caller is an agent', () => {
+      describe('when the token is paused', () => {
+        it('should unpause the token', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent },
@@ -252,29 +252,29 @@ describe("Token - Information", () => {
           await token.connect(tokenAgent).pause();
           const tx = await token.connect(tokenAgent).unpause();
           await expect(tx)
-            .to.emit(token, "Unpaused")
+            .to.emit(token, 'Unpaused')
             .withArgs(tokenAgent.address);
           expect(await token.paused()).to.be.false;
         });
       });
 
-      describe("when the token is not paused", () => {
-        it("should revert", async () => {
+      describe('when the token is not paused', () => {
+        it('should revert', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent },
           } = await loadFixture(deployFullSuiteFixture);
           await expect(token.connect(tokenAgent).unpause()).to.be.revertedWith(
-            "Pausable: not paused"
+            'Pausable: not paused',
           );
         });
       });
     });
   });
 
-  describe(".setAddressFrozen", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.setAddressFrozen', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
@@ -282,15 +282,15 @@ describe("Token - Information", () => {
         await expect(
           token
             .connect(anotherWallet)
-            .setAddressFrozen(anotherWallet.address, true)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+            .setAddressFrozen(anotherWallet.address, true),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
   });
 
-  describe(".freezePartialTokens", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.freezePartialTokens', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
@@ -298,14 +298,14 @@ describe("Token - Information", () => {
         await expect(
           token
             .connect(anotherWallet)
-            .freezePartialTokens(anotherWallet.address, 1)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+            .freezePartialTokens(anotherWallet.address, 1),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when sender is an agent", () => {
-      describe("when amounts exceed current balance", () => {
-        it("should revert", async () => {
+    describe('when sender is an agent', () => {
+      describe('when amounts exceed current balance', () => {
+        it('should revert', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent, anotherWallet },
@@ -313,16 +313,16 @@ describe("Token - Information", () => {
           await expect(
             token
               .connect(tokenAgent)
-              .freezePartialTokens(anotherWallet.address, 1)
-          ).to.be.revertedWith("Amount exceeds available balance");
+              .freezePartialTokens(anotherWallet.address, 1),
+          ).to.be.revertedWith('Amount exceeds available balance');
         });
       });
     });
   });
 
-  describe(".unfreezePartialTokens", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.unfreezePartialTokens', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet },
@@ -330,14 +330,14 @@ describe("Token - Information", () => {
         await expect(
           token
             .connect(anotherWallet)
-            .unfreezePartialTokens(anotherWallet.address, 1)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+            .unfreezePartialTokens(anotherWallet.address, 1),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when sender is an agent", () => {
-      describe("when amounts exceed current frozen balance", () => {
-        it("should revert", async () => {
+    describe('when sender is an agent', () => {
+      describe('when amounts exceed current frozen balance', () => {
+        it('should revert', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent, anotherWallet },
@@ -345,9 +345,9 @@ describe("Token - Information", () => {
           await expect(
             token
               .connect(tokenAgent)
-              .unfreezePartialTokens(anotherWallet.address, 1)
+              .unfreezePartialTokens(anotherWallet.address, 1),
           ).to.be.revertedWith(
-            "Amount should be less than or equal to frozen tokens"
+            'Amount should be less than or equal to frozen tokens',
           );
         });
       });

--- a/test/token/token-recovery.test.ts
+++ b/test/token/token-recovery.test.ts
@@ -1,12 +1,12 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { deployFullSuiteFixture } from "../fixtures/deploy-full-suite.fixture";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { deployFullSuiteFixture } from '../fixtures/deploy-full-suite.fixture';
 
-describe("Token - Recovery", () => {
-  describe(".recoveryAddress()", () => {
-    describe("when sender is not an agent", () => {
-      it("should reverts", async () => {
+describe('Token - Recovery', () => {
+  describe('.recoveryAddress()', () => {
+    describe('when sender is not an agent', () => {
+      it('should reverts', async () => {
         const {
           suite: { token },
           accounts: { bobWallet, anotherWallet },
@@ -18,12 +18,12 @@ describe("Token - Recovery", () => {
           .addKey(
             ethers.utils.keccak256(
               ethers.utils.defaultAbiCoder.encode(
-                ["address"],
-                [anotherWallet.address]
-              )
+                ['address'],
+                [anotherWallet.address],
+              ),
             ),
             1,
-            1
+            1,
           );
 
         await expect(
@@ -32,15 +32,15 @@ describe("Token - Recovery", () => {
             .recoveryAddress(
               bobWallet.address,
               anotherWallet.address,
-              bobIdentity.address
-            )
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+              bobIdentity.address,
+            ),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when sender is an agent", () => {
-      describe("when wallet to recover has no balance", () => {
-        it("should revert", async () => {
+    describe('when sender is an agent', () => {
+      describe('when wallet to recover has no balance', () => {
+        it('should revert', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent, aliceWallet, bobWallet, anotherWallet },
@@ -51,7 +51,7 @@ describe("Token - Recovery", () => {
             .connect(bobWallet)
             .transfer(
               aliceWallet.address,
-              await token.balanceOf(bobWallet.address)
+              await token.balanceOf(bobWallet.address),
             );
 
           await expect(
@@ -60,14 +60,14 @@ describe("Token - Recovery", () => {
               .recoveryAddress(
                 bobWallet.address,
                 anotherWallet.address,
-                bobIdentity.address
-              )
-          ).to.be.revertedWith("no tokens to recover");
+                bobIdentity.address,
+              ),
+          ).to.be.revertedWith('no tokens to recover');
         });
       });
 
-      describe("when new wallet is not authorized on the identity", () => {
-        it("should revert", async () => {
+      describe('when new wallet is not authorized on the identity', () => {
+        it('should revert', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent, bobWallet, anotherWallet },
@@ -80,14 +80,14 @@ describe("Token - Recovery", () => {
               .recoveryAddress(
                 bobWallet.address,
                 anotherWallet.address,
-                bobIdentity.address
-              )
-          ).to.be.revertedWith("Recovery not possible");
+                bobIdentity.address,
+              ),
+          ).to.be.revertedWith('Recovery not possible');
         });
       });
 
-      describe("when wallet is frozen", () => {
-        it("should recover and freeze the new wallet", async () => {
+      describe('when wallet is frozen', () => {
+        it('should recover and freeze the new wallet', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent, bobWallet, anotherWallet },
@@ -99,12 +99,12 @@ describe("Token - Recovery", () => {
             .addKey(
               ethers.utils.keccak256(
                 ethers.utils.defaultAbiCoder.encode(
-                  ["address"],
-                  [anotherWallet.address]
-                )
+                  ['address'],
+                  [anotherWallet.address],
+                ),
               ),
               1,
-              1
+              1,
             );
 
           await token
@@ -116,25 +116,25 @@ describe("Token - Recovery", () => {
             .recoveryAddress(
               bobWallet.address,
               anotherWallet.address,
-              bobIdentity.address
+              bobIdentity.address,
             );
           await expect(token.isFrozen(anotherWallet.address)).to.be.eventually
             .true;
           await expect(tx)
-            .to.emit(token, "RecoverySuccess")
+            .to.emit(token, 'RecoverySuccess')
             .withArgs(
               bobWallet.address,
               anotherWallet.address,
-              bobIdentity.address
+              bobIdentity.address,
             );
           await expect(tx)
-            .to.emit(token, "AddressFrozen")
+            .to.emit(token, 'AddressFrozen')
             .withArgs(anotherWallet.address, true, tokenAgent.address);
         });
       });
 
-      describe("when wallet has frozen token", () => {
-        it("should recover and freeze tokens on the new wallet", async () => {
+      describe('when wallet has frozen token', () => {
+        it('should recover and freeze tokens on the new wallet', async () => {
           const {
             suite: { token },
             accounts: { tokenAgent, bobWallet, anotherWallet },
@@ -146,12 +146,12 @@ describe("Token - Recovery", () => {
             .addKey(
               ethers.utils.keccak256(
                 ethers.utils.defaultAbiCoder.encode(
-                  ["address"],
-                  [anotherWallet.address]
-                )
+                  ['address'],
+                  [anotherWallet.address],
+                ),
               ),
               1,
-              1
+              1,
             );
 
           await token
@@ -163,20 +163,20 @@ describe("Token - Recovery", () => {
             .recoveryAddress(
               bobWallet.address,
               anotherWallet.address,
-              bobIdentity.address
+              bobIdentity.address,
             );
           await expect(
-            token.getFrozenTokens(anotherWallet.address)
+            token.getFrozenTokens(anotherWallet.address),
           ).to.be.eventually.eq(50);
           await expect(tx)
-            .to.emit(token, "RecoverySuccess")
+            .to.emit(token, 'RecoverySuccess')
             .withArgs(
               bobWallet.address,
               anotherWallet.address,
-              bobIdentity.address
+              bobIdentity.address,
             );
           await expect(tx)
-            .to.emit(token, "TokensFrozen")
+            .to.emit(token, 'TokensFrozen')
             .withArgs(anotherWallet.address, 50);
         });
       });

--- a/test/token/token-transfer.test.ts
+++ b/test/token/token-transfer.test.ts
@@ -1,14 +1,14 @@
-import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 import {
   deployFullSuiteFixture,
   deploySuiteWithModularCompliancesFixture,
-} from "../fixtures/deploy-full-suite.fixture";
+} from '../fixtures/deploy-full-suite.fixture';
 
-describe("Token - Transfers", () => {
-  describe(".approve()", () => {
-    it("should approve a contract to spend a certain amount of tokens", async () => {
+describe('Token - Transfers', () => {
+  describe('.approve()', () => {
+    it('should approve a contract to spend a certain amount of tokens', async () => {
       const {
         suite: { token },
         accounts: { aliceWallet, anotherWallet },
@@ -18,17 +18,17 @@ describe("Token - Transfers", () => {
         .connect(aliceWallet)
         .approve(anotherWallet.address, 100);
       await expect(tx)
-        .to.emit(token, "Approval")
+        .to.emit(token, 'Approval')
         .withArgs(aliceWallet.address, anotherWallet.address, 100);
 
       await expect(
-        token.allowance(aliceWallet.address, anotherWallet.address)
+        token.allowance(aliceWallet.address, anotherWallet.address),
       ).to.eventually.equal(100);
     });
   });
 
-  describe(".increaseAllowance()", () => {
-    it("should increase the allowance of a contract to spend a certain amount of tokens", async () => {
+  describe('.increaseAllowance()', () => {
+    it('should increase the allowance of a contract to spend a certain amount of tokens', async () => {
       const {
         suite: { token },
         accounts: { aliceWallet, anotherWallet },
@@ -40,17 +40,17 @@ describe("Token - Transfers", () => {
         .connect(aliceWallet)
         .increaseAllowance(anotherWallet.address, 100);
       await expect(tx)
-        .to.emit(token, "Approval")
+        .to.emit(token, 'Approval')
         .withArgs(aliceWallet.address, anotherWallet.address, 200);
 
       await expect(
-        token.allowance(aliceWallet.address, anotherWallet.address)
+        token.allowance(aliceWallet.address, anotherWallet.address),
       ).to.eventually.equal(200);
     });
   });
 
-  describe(".decreaseAllowance()", () => {
-    it("should decrease the allowance of a contract to spend a certain amount of tokens", async () => {
+  describe('.decreaseAllowance()', () => {
+    it('should decrease the allowance of a contract to spend a certain amount of tokens', async () => {
       const {
         suite: { token },
         accounts: { aliceWallet, anotherWallet },
@@ -62,18 +62,18 @@ describe("Token - Transfers", () => {
         .connect(aliceWallet)
         .decreaseAllowance(anotherWallet.address, 100);
       await expect(tx)
-        .to.emit(token, "Approval")
+        .to.emit(token, 'Approval')
         .withArgs(aliceWallet.address, anotherWallet.address, 50);
 
       await expect(
-        token.allowance(aliceWallet.address, anotherWallet.address)
+        token.allowance(aliceWallet.address, anotherWallet.address),
       ).to.eventually.equal(50);
     });
   });
 
-  describe(".transfer()", () => {
-    describe("when the token is paused", () => {
-      it("should revert", async () => {
+  describe('.transfer()', () => {
+    describe('when the token is paused', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet, tokenAgent },
@@ -82,13 +82,13 @@ describe("Token - Transfers", () => {
         await token.connect(tokenAgent).pause();
 
         await expect(
-          token.connect(aliceWallet).transfer(bobWallet.address, 100)
-        ).to.be.revertedWith("Pausable: paused");
+          token.connect(aliceWallet).transfer(bobWallet.address, 100),
+        ).to.be.revertedWith('Pausable: paused');
       });
     });
 
-    describe("when the recipient balance is frozen", () => {
-      it("should revert", async () => {
+    describe('when the recipient balance is frozen', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { tokenAgent, aliceWallet, bobWallet },
@@ -99,13 +99,13 @@ describe("Token - Transfers", () => {
           .setAddressFrozen(bobWallet.address, true);
 
         await expect(
-          token.connect(aliceWallet).transfer(bobWallet.address, 100)
-        ).to.be.revertedWith("wallet is frozen");
+          token.connect(aliceWallet).transfer(bobWallet.address, 100),
+        ).to.be.revertedWith('wallet is frozen');
       });
     });
 
-    describe("when the sender balance is frozen", () => {
-      it("should revert", async () => {
+    describe('when the sender balance is frozen', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { tokenAgent, aliceWallet, bobWallet },
@@ -116,13 +116,13 @@ describe("Token - Transfers", () => {
           .setAddressFrozen(aliceWallet.address, true);
 
         await expect(
-          token.connect(aliceWallet).transfer(bobWallet.address, 100)
-        ).to.be.revertedWith("wallet is frozen");
+          token.connect(aliceWallet).transfer(bobWallet.address, 100),
+        ).to.be.revertedWith('wallet is frozen');
       });
     });
 
-    describe("when the sender has not enough balance", () => {
-      it("should revert", async () => {
+    describe('when the sender has not enough balance', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet },
@@ -133,13 +133,13 @@ describe("Token - Transfers", () => {
         await expect(
           token
             .connect(aliceWallet)
-            .transfer(bobWallet.address, balance.add(1000))
-        ).to.be.revertedWith("Insufficient Balance");
+            .transfer(bobWallet.address, balance.add(1000)),
+        ).to.be.revertedWith('Insufficient Balance');
       });
     });
 
-    describe("when the sender has not enough balance unfrozen", () => {
-      it("should revert", async () => {
+    describe('when the sender has not enough balance unfrozen', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet, tokenAgent },
@@ -151,45 +151,45 @@ describe("Token - Transfers", () => {
           .freezePartialTokens(aliceWallet.address, balance.sub(100));
 
         await expect(
-          token.connect(aliceWallet).transfer(bobWallet.address, balance)
-        ).to.be.revertedWith("Insufficient Balance");
+          token.connect(aliceWallet).transfer(bobWallet.address, balance),
+        ).to.be.revertedWith('Insufficient Balance');
       });
     });
 
-    describe("when the recipient identity is not verified", () => {
-      it("should revert", async () => {
+    describe('when the recipient identity is not verified', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, anotherWallet },
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(
-          token.connect(aliceWallet).transfer(anotherWallet.address, 100)
-        ).to.be.revertedWith("Transfer not possible");
+          token.connect(aliceWallet).transfer(anotherWallet.address, 100),
+        ).to.be.revertedWith('Transfer not possible');
       });
     });
 
-    describe("when the transfer breaks compliance rules", () => {
-      it("should revert", async () => {
+    describe('when the transfer breaks compliance rules', () => {
+      it('should revert', async () => {
         const {
           suite: { token, compliance },
           accounts: { aliceWallet, bobWallet },
         } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
         const complianceModuleA = await ethers.deployContract(
-          "CountryAllowModule"
+          'CountryAllowModule',
         );
         await compliance.addModule(complianceModuleA.address);
         await token.setCompliance(compliance.address);
 
         await expect(
-          token.connect(aliceWallet).transfer(bobWallet.address, 100)
-        ).to.be.revertedWith("Transfer not possible");
+          token.connect(aliceWallet).transfer(bobWallet.address, 100),
+        ).to.be.revertedWith('Transfer not possible');
       });
     });
 
-    describe("when the transfer is compliant", () => {
-      it("should transfer tokens", async () => {
+    describe('when the transfer is compliant', () => {
+      it('should transfer tokens', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet },
@@ -199,14 +199,14 @@ describe("Token - Transfers", () => {
           .connect(aliceWallet)
           .transfer(bobWallet.address, 100);
         await expect(tx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(aliceWallet.address, bobWallet.address, 100);
       });
     });
   });
 
-  describe(".batchTransfer()", () => {
-    it("should transfer tokens", async () => {
+  describe('.batchTransfer()', () => {
+    it('should transfer tokens', async () => {
       const {
         suite: { token },
         accounts: { aliceWallet, bobWallet },
@@ -216,17 +216,17 @@ describe("Token - Transfers", () => {
         .connect(aliceWallet)
         .batchTransfer([bobWallet.address, bobWallet.address], [100, 200]);
       await expect(tx)
-        .to.emit(token, "Transfer")
+        .to.emit(token, 'Transfer')
         .withArgs(aliceWallet.address, bobWallet.address, 100);
       await expect(tx)
-        .to.emit(token, "Transfer")
+        .to.emit(token, 'Transfer')
         .withArgs(aliceWallet.address, bobWallet.address, 200);
     });
   });
 
-  describe(".transferFrom()", () => {
-    describe("when the token is paused", () => {
-      it("should revert", async () => {
+  describe('.transferFrom()', () => {
+    describe('when the token is paused', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet, tokenAgent },
@@ -237,13 +237,13 @@ describe("Token - Transfers", () => {
         await expect(
           token
             .connect(aliceWallet)
-            .transferFrom(aliceWallet.address, bobWallet.address, 100)
-        ).to.be.revertedWith("Pausable: paused");
+            .transferFrom(aliceWallet.address, bobWallet.address, 100),
+        ).to.be.revertedWith('Pausable: paused');
       });
     });
 
-    describe("when sender address is frozen", () => {
-      it("should revert", async () => {
+    describe('when sender address is frozen', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet, tokenAgent },
@@ -256,13 +256,13 @@ describe("Token - Transfers", () => {
         await expect(
           token
             .connect(aliceWallet)
-            .transferFrom(aliceWallet.address, bobWallet.address, 100)
-        ).to.be.revertedWith("wallet is frozen");
+            .transferFrom(aliceWallet.address, bobWallet.address, 100),
+        ).to.be.revertedWith('wallet is frozen');
       });
     });
 
-    describe("when recipient address is frozen", () => {
-      it("should revert", async () => {
+    describe('when recipient address is frozen', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet, tokenAgent },
@@ -275,13 +275,13 @@ describe("Token - Transfers", () => {
         await expect(
           token
             .connect(aliceWallet)
-            .transferFrom(aliceWallet.address, bobWallet.address, 100)
-        ).to.be.revertedWith("wallet is frozen");
+            .transferFrom(aliceWallet.address, bobWallet.address, 100),
+        ).to.be.revertedWith('wallet is frozen');
       });
     });
 
-    describe("when sender has not enough balance", () => {
-      it("should revert", async () => {
+    describe('when sender has not enough balance', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet },
@@ -295,14 +295,14 @@ describe("Token - Transfers", () => {
             .transferFrom(
               aliceWallet.address,
               bobWallet.address,
-              balance.add(1000)
-            )
-        ).to.be.revertedWith("Insufficient Balance");
+              balance.add(1000),
+            ),
+        ).to.be.revertedWith('Insufficient Balance');
       });
     });
 
-    describe("when sender has not enough balance unfrozen", () => {
-      it("should revert", async () => {
+    describe('when sender has not enough balance unfrozen', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet, tokenAgent },
@@ -316,13 +316,13 @@ describe("Token - Transfers", () => {
         await expect(
           token
             .connect(aliceWallet)
-            .transferFrom(aliceWallet.address, bobWallet.address, balance)
-        ).to.be.revertedWith("Insufficient Balance");
+            .transferFrom(aliceWallet.address, bobWallet.address, balance),
+        ).to.be.revertedWith('Insufficient Balance');
       });
     });
 
-    describe("when the recipient identity is not verified", () => {
-      it("should revert", async () => {
+    describe('when the recipient identity is not verified', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, anotherWallet },
@@ -331,20 +331,20 @@ describe("Token - Transfers", () => {
         await expect(
           token
             .connect(aliceWallet)
-            .transferFrom(aliceWallet.address, anotherWallet.address, 100)
-        ).to.be.revertedWith("Transfer not possible");
+            .transferFrom(aliceWallet.address, anotherWallet.address, 100),
+        ).to.be.revertedWith('Transfer not possible');
       });
     });
 
-    describe("when the transfer breaks compliance rules", () => {
-      it("should revert", async () => {
+    describe('when the transfer breaks compliance rules', () => {
+      it('should revert', async () => {
         const {
           suite: { token, compliance },
           accounts: { aliceWallet, bobWallet },
         } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
         const complianceModuleA = await ethers.deployContract(
-          "CountryAllowModule"
+          'CountryAllowModule',
         );
         await compliance.addModule(complianceModuleA.address);
         await token.setCompliance(compliance.address);
@@ -352,13 +352,13 @@ describe("Token - Transfers", () => {
         await expect(
           token
             .connect(aliceWallet)
-            .transferFrom(aliceWallet.address, bobWallet.address, 100)
-        ).to.be.revertedWith("Transfer not possible");
+            .transferFrom(aliceWallet.address, bobWallet.address, 100),
+        ).to.be.revertedWith('Transfer not possible');
       });
     });
 
-    describe("when the transfer is compliant", () => {
-      it("should transfer tokens and reduce allowance of transferred value", async () => {
+    describe('when the transfer is compliant', () => {
+      it('should transfer tokens and reduce allowance of transferred value', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet, anotherWallet },
@@ -370,19 +370,19 @@ describe("Token - Transfers", () => {
           .connect(anotherWallet)
           .transferFrom(aliceWallet.address, bobWallet.address, 100);
         await expect(tx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(aliceWallet.address, bobWallet.address, 100);
 
         await expect(
-          token.allowance(aliceWallet.address, anotherWallet.address)
+          token.allowance(aliceWallet.address, anotherWallet.address),
         ).to.be.eventually.equal(0);
       });
     });
   });
 
-  describe(".forcedTransfer()", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.forcedTransfer()', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet },
@@ -391,13 +391,13 @@ describe("Token - Transfers", () => {
         await expect(
           token
             .connect(aliceWallet)
-            .forcedTransfer(aliceWallet.address, bobWallet.address, 100)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+            .forcedTransfer(aliceWallet.address, bobWallet.address, 100),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when source wallet has not enough balance", () => {
-      it("should revert", async () => {
+    describe('when source wallet has not enough balance', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet, tokenAgent },
@@ -411,14 +411,14 @@ describe("Token - Transfers", () => {
             .forcedTransfer(
               aliceWallet.address,
               bobWallet.address,
-              balance.add(1000)
-            )
-        ).to.be.revertedWith("sender balance too low");
+              balance.add(1000),
+            ),
+        ).to.be.revertedWith('sender balance too low');
       });
     });
 
-    describe("when recipient identity is not verified", () => {
-      it("should revert", async () => {
+    describe('when recipient identity is not verified', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, anotherWallet, tokenAgent },
@@ -427,20 +427,20 @@ describe("Token - Transfers", () => {
         await expect(
           token
             .connect(tokenAgent)
-            .forcedTransfer(aliceWallet.address, anotherWallet.address, 100)
-        ).to.be.revertedWith("Transfer not possible");
+            .forcedTransfer(aliceWallet.address, anotherWallet.address, 100),
+        ).to.be.revertedWith('Transfer not possible');
       });
     });
 
-    describe("when the transfer breaks compliance rules", () => {
-      it("should still transfer tokens", async () => {
+    describe('when the transfer breaks compliance rules', () => {
+      it('should still transfer tokens', async () => {
         const {
           suite: { token, compliance },
           accounts: { aliceWallet, bobWallet, tokenAgent },
         } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
         const complianceModuleA = await ethers.deployContract(
-          "CountryAllowModule"
+          'CountryAllowModule',
         );
         await compliance.addModule(complianceModuleA.address);
         await token.setCompliance(compliance.address);
@@ -449,13 +449,13 @@ describe("Token - Transfers", () => {
           .connect(tokenAgent)
           .forcedTransfer(aliceWallet.address, bobWallet.address, 100);
         await expect(tx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(aliceWallet.address, bobWallet.address, 100);
       });
     });
 
-    describe("when amount is greater than unfrozen balance", () => {
-      it("should unfroze tokens", async () => {
+    describe('when amount is greater than unfrozen balance', () => {
+      it('should unfroze tokens', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, bobWallet, tokenAgent },
@@ -471,84 +471,84 @@ describe("Token - Transfers", () => {
           .forcedTransfer(
             aliceWallet.address,
             bobWallet.address,
-            balance.sub(50)
+            balance.sub(50),
           );
         await expect(tx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(aliceWallet.address, bobWallet.address, balance.sub(50));
         await expect(tx)
-          .to.emit(token, "TokensUnfrozen")
+          .to.emit(token, 'TokensUnfrozen')
           .withArgs(aliceWallet.address, balance.sub(150));
         await expect(
-          token.getFrozenTokens(aliceWallet.address)
+          token.getFrozenTokens(aliceWallet.address),
         ).to.be.eventually.equal(50);
       });
     });
   });
 
-  describe(".mint", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.mint', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet },
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(
-          token.connect(aliceWallet).mint(aliceWallet.address, 100)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+          token.connect(aliceWallet).mint(aliceWallet.address, 100),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when recipient identity is not verified", () => {
-      it("should revert", async () => {
+    describe('when recipient identity is not verified', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { anotherWallet, tokenAgent },
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(
-          token.connect(tokenAgent).mint(anotherWallet.address, 100)
-        ).to.be.revertedWith("Identity is not verified.");
+          token.connect(tokenAgent).mint(anotherWallet.address, 100),
+        ).to.be.revertedWith('Identity is not verified.');
       });
     });
 
-    describe("when the mint breaks compliance rules", () => {
-      it("should revert", async () => {
+    describe('when the mint breaks compliance rules', () => {
+      it('should revert', async () => {
         const {
           suite: { token, compliance },
           accounts: { aliceWallet, tokenAgent },
         } = await loadFixture(deploySuiteWithModularCompliancesFixture);
 
         const complianceModuleA = await ethers.deployContract(
-          "CountryAllowModule"
+          'CountryAllowModule',
         );
         await compliance.addModule(complianceModuleA.address);
         await token.setCompliance(compliance.address);
 
         await expect(
-          token.connect(tokenAgent).mint(aliceWallet.address, 100)
-        ).to.be.revertedWith("Compliance not followed");
+          token.connect(tokenAgent).mint(aliceWallet.address, 100),
+        ).to.be.revertedWith('Compliance not followed');
       });
     });
   });
 
-  describe(".burn()", () => {
-    describe("when sender is not an agent", () => {
-      it("should revert", async () => {
+  describe('.burn()', () => {
+    describe('when sender is not an agent', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet },
         } = await loadFixture(deployFullSuiteFixture);
 
         await expect(
-          token.connect(aliceWallet).burn(aliceWallet.address, 100)
-        ).to.be.revertedWith("AgentRole: caller does not have the Agent role");
+          token.connect(aliceWallet).burn(aliceWallet.address, 100),
+        ).to.be.revertedWith('AgentRole: caller does not have the Agent role');
       });
     });
 
-    describe("when source wallet has not enough balance", () => {
-      it("should revert", async () => {
+    describe('when source wallet has not enough balance', () => {
+      it('should revert', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, tokenAgent },
@@ -557,13 +557,15 @@ describe("Token - Transfers", () => {
         const balance = await token.balanceOf(aliceWallet.address);
 
         await expect(
-          token.connect(tokenAgent).burn(aliceWallet.address, balance.add(1000))
-        ).to.be.revertedWith("cannot burn more than balance");
+          token
+            .connect(tokenAgent)
+            .burn(aliceWallet.address, balance.add(1000)),
+        ).to.be.revertedWith('cannot burn more than balance');
       });
     });
 
-    describe("when amount to burn is greater that unfrozen balance", () => {
-      it("should burn and decrease frozen balance", async () => {
+    describe('when amount to burn is greater that unfrozen balance', () => {
+      it('should burn and decrease frozen balance', async () => {
         const {
           suite: { token },
           accounts: { aliceWallet, tokenAgent },
@@ -578,17 +580,17 @@ describe("Token - Transfers", () => {
           .connect(tokenAgent)
           .burn(aliceWallet.address, balance.sub(50));
         await expect(tx)
-          .to.emit(token, "Transfer")
+          .to.emit(token, 'Transfer')
           .withArgs(
             aliceWallet.address,
             ethers.constants.AddressZero,
-            balance.sub(50)
+            balance.sub(50),
           );
         await expect(tx)
-          .to.emit(token, "TokensUnfrozen")
+          .to.emit(token, 'TokensUnfrozen')
           .withArgs(aliceWallet.address, balance.sub(150));
         await expect(
-          token.getFrozenTokens(aliceWallet.address)
+          token.getFrozenTokens(aliceWallet.address),
         ).to.be.eventually.equal(50);
       });
     });


### PR DESCRIPTION
- Update prettier to use single quotes (this is what we have been using mainly).
- Remove deactivation of some linter rules (no-empty-blocks) for instance. I think you ignored them because prettier changed single lines function to multi-line function, making the ignore rule for line comments ineffective.
- Update linter config from node recommended to typescript recommended.